### PR TITLE
[ADD/#53] DataStore에 사용자 정보 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,10 +32,6 @@
         <activity
             android:name=".presentation.onboarding.OnBoardingActivity"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".presentation.group.GroupListActivity"
@@ -64,6 +60,13 @@
             android:exported="false" />
         <activity android:name=".presentation.signup.finish.SignUpFinishActivity"
             android:exported="false" />
+        <activity android:name=".presentation.splash.SplashActivity"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/app/src/main/java/com/teumteum/teumteum/di/RepositoryModule.kt
+++ b/app/src/main/java/com/teumteum/teumteum/di/RepositoryModule.kt
@@ -3,9 +3,11 @@ package com.teumteum.teumteum.di
 import com.teumteum.data.repository.GroupRepositoryImpl
 import com.teumteum.data.repository.HomeRepositoryImpl
 import com.teumteum.data.repository.SampleRepositoryImpl
+import com.teumteum.data.repository.UserRepositoryImpl
 import com.teumteum.domain.repository.GroupRepository
 import com.teumteum.domain.repository.HomeRepository
 import com.teumteum.domain.repository.SampleRepository
+import com.teumteum.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -28,4 +30,8 @@ interface RepositoryModule {
     @Singleton
     @Binds
     fun provideGroupRepository(groupRepositoryImpl: GroupRepositoryImpl): GroupRepository
+
+    @Singleton
+    @Binds
+    fun provideUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/onboarding/OnBoardingActivity.kt
@@ -17,7 +17,6 @@ import com.teumteum.teumteum.presentation.onboarding.adapter.OnBoardingViewPager
 import com.teumteum.teumteum.presentation.signin.SignInActivity
 import dagger.hilt.android.AndroidEntryPoint
 
-
 @AndroidEntryPoint
 class OnBoardingActivity
     : BindingActivity<ActivityOnboardingBinding>(R.layout.activity_onboarding), AppBarLayout {
@@ -39,7 +38,7 @@ class OnBoardingActivity
         initAppBarLayout()
         initViewPagerItem()
         initViewPager()
-        setUpListener()
+//        setUpListener()
     }
 
     override val appBarBinding: LayoutCommonAppbarBinding

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signin/SignInActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signin/SignInActivity.kt
@@ -2,16 +2,20 @@ package com.teumteum.teumteum.presentation.signin
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import com.teumteum.base.BindingActivity
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ActivitySigninBinding
-import com.teumteum.teumteum.presentation.signup.intro.CardIntroActivity
 import com.teumteum.teumteum.presentation.signup.terms.TermsActivity
+import com.teumteum.teumteum.presentation.splash.SplashViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class SignInActivity
     : BindingActivity<ActivitySigninBinding>(R.layout.activity_signin){
+
+    private val splashViewModel by viewModels<SplashViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +35,10 @@ class SignInActivity
                 finish()
             }
         }
+    }
+
+    private fun getUserInfoExample() {
+        Timber.tag("teum-datastore").d(splashViewModel.getUserInfo().toString())
     }
 
     companion object {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/splash/SplashActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/splash/SplashActivity.kt
@@ -1,0 +1,72 @@
+package com.teumteum.teumteum.presentation.splash
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.activity.viewModels
+import com.teumteum.base.BindingActivity
+import com.teumteum.domain.entity.JobEntity
+import com.teumteum.domain.entity.UserInfo
+import com.teumteum.teumteum.R
+import com.teumteum.teumteum.databinding.ActivitySplashBinding
+import com.teumteum.teumteum.presentation.MainActivity
+import com.teumteum.teumteum.presentation.onboarding.OnBoardingActivity
+import com.teumteum.teumteum.presentation.signin.SignInActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SplashActivity
+    : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
+
+    private val viewModel by viewModels<SplashViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        initSplash()
+    }
+
+    private fun initSplash() {
+        Handler(Looper.getMainLooper()).postDelayed({
+            startOnBoarding()
+        }, 3000)
+    }
+
+    private fun startOnBoarding() {
+        startActivity(Intent(this, OnBoardingActivity::class.java))
+        finish()
+    }
+
+    private fun saveUserInfoExample() {
+        val userInfo = UserInfo(
+            id = 0L,
+            name = "테스트",
+            birth = "2000.01.01",
+            characterId = 0,
+            mannerTemperature = 36,
+            activityArea = "서울특별시 강남구",
+            mbti = "ENFP",
+            status = "학생",
+            goal = "",
+            job = JobEntity(
+                name = "학교",
+                `class` = "개발",
+                detailClass = "AOS 개발자"
+            ),
+            interests = listOf("IT", "모여서 각자 일하기")
+        )
+        viewModel.saveUserInfo(userInfo)
+    }
+
+    private fun startSignIn() {
+        startActivity(Intent(this, SignInActivity::class.java))
+        finish()
+    }
+
+    private fun startHomeScreen() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+
+}

--- a/app/src/main/java/com/teumteum/teumteum/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,29 @@
+package com.teumteum.teumteum.presentation.splash
+
+import androidx.lifecycle.ViewModel
+import com.google.gson.GsonBuilder
+import com.teumteum.domain.entity.UserInfo
+import com.teumteum.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    val repository: UserRepository
+) : ViewModel() {
+
+    private val gsonBuilder = GsonBuilder().create()
+
+    fun saveUserInfo(userInfo: UserInfo) {
+        Timber.tag("teum-datastore").d("saveUserInfo: $userInfo")
+        repository.saveUserInfo(gsonBuilder.toJson(userInfo))
+    }
+
+    fun getUserInfo(): UserInfo {
+        val userInfoGson = gsonBuilder.fromJson(repository.getUserInfo(), UserInfo::class.java)
+        Timber.tag("teum-datastore").d("getUserInfo: $userInfoGson")
+        return userInfoGson
+    }
+}

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:theme="@style/Theme.TeumTeum"
+        android:background="@color/background"
+        >
+
+        <ImageView
+            android:id="@+id/iv_logo"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
+            android:src="@drawable/ic_logo_title_symbol"
+            app:layout_constraintVertical_bias="0.42"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/core/data/src/main/java/com/teumteum/data/local/TeumTeumDataStoreImpl.kt
+++ b/core/data/src/main/java/com/teumteum/data/local/TeumTeumDataStoreImpl.kt
@@ -3,6 +3,7 @@ package com.teumteum.data.local
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.teumteum.domain.TeumTeumDataStore
+import com.teumteum.domain.entity.UserInfo
 import javax.inject.Inject
 
 class TeumTeumDataStoreImpl @Inject constructor(
@@ -20,11 +21,16 @@ class TeumTeumDataStoreImpl @Inject constructor(
         get() = userPref.getBoolean(PREF_IS_LOGIN, false)
         set(value) = userPref.edit { putBoolean(PREF_IS_LOGIN, value) }
 
+    override var userInfo: String
+        get() = userPref.getString(PREF_USER_INFO, "") ?: ""
+        set(value) = userPref.edit { putString(PREF_USER_INFO, value) }
+
     override fun clearLocalPref() = userPref.edit { clear() }
 
     companion object {
         private const val PREF_USER_TOKEN = "USER_TOKEN"
         private const val PREF_REFRESH_TOKEN = "REFRESH_TOKEN"
         private const val PREF_IS_LOGIN = "IS_LOGIN"
+        private const val PREF_USER_INFO = "USER_INFO"
     }
 }

--- a/core/data/src/main/java/com/teumteum/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teumteum/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.teumteum.data.repository
+
+import com.teumteum.domain.TeumTeumDataStore
+import com.teumteum.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val dataStore: TeumTeumDataStore,
+) : UserRepository {
+    override fun getUserInfo(): String {
+        return dataStore.userInfo
+    }
+
+    override fun saveUserInfo(userInfo: String) {
+        dataStore.userInfo = userInfo
+    }
+}

--- a/core/domain/src/main/java/com/teumteum/domain/TeumTeumDataStore.kt
+++ b/core/domain/src/main/java/com/teumteum/domain/TeumTeumDataStore.kt
@@ -5,5 +5,7 @@ interface TeumTeumDataStore {
     var refreshToken: String
     var isLogin: Boolean
 
+    var userInfo: String
+
     fun clearLocalPref()
 }

--- a/core/domain/src/main/java/com/teumteum/domain/entity/UserInfo.kt
+++ b/core/domain/src/main/java/com/teumteum/domain/entity/UserInfo.kt
@@ -1,0 +1,25 @@
+package com.teumteum.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserInfo (
+    val id: Long,
+    val name: String,
+    val birth: String, // YYYY.MM.DD
+    val characterId: Int,
+    val mannerTemperature: Int,
+    val activityArea: String,
+    val mbti: String,
+    val status: String,
+    val goal: String,
+    val job: JobEntity,
+    val interests: List<String>
+)
+
+@Serializable
+data class JobEntity (
+    val name: String,
+    val `class`: String,
+    val detailClass: String
+)

--- a/core/domain/src/main/java/com/teumteum/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/teumteum/domain/repository/UserRepository.kt
@@ -1,0 +1,6 @@
+package com.teumteum.domain.repository
+
+interface UserRepository {
+    fun saveUserInfo(userInfo: String)
+    fun getUserInfo(): String
+}


### PR DESCRIPTION
## 📌 개요
- open #53 

## ✨ 작업 내용
- [x] DataStore에 사용자 정보 필드 추가
- [x] Splash 화면 추가
- [ ] 소셜로그인 API 연결
- [ ] 내 정보 받기 API 연결
- [ ] 소셜로그인 성공 이후 사용자 정보 저장

## ✨ PR 포인트

