### PR TITLE
[FEAT/#54] 커스텀 카드 뷰 앞면 ui 보충

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/FrontCardView.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/FrontCardView.kt
@@ -1,9 +1,9 @@
 package com.teumteum.teumteum.util.custom.view
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.cardview.widget.CardView
@@ -20,7 +20,7 @@ import com.teumteum.teumteum.util.extension.dpToPx
  * xml, compose 모든 환경에서 뷰를 재활용 할 수 있게 커스텀뷰로 제작
  */
 class FrontCardView : CardView {
-    private val matchParent = ConstraintLayout.LayoutParams.PARENT_ID
+    private val layoutParent = ConstraintLayout.LayoutParams.PARENT_ID
     private var frontCard = FrontCard()
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
@@ -53,15 +53,11 @@ class FrontCardView : CardView {
      * 카드 배경 설정
      */
     private fun setFrontCardBackground(context: Context) {
-        setCardBackgroundColor(
-            ColorStateList.valueOf(
-                ContextCompat.getColor(
-                    context,
-                    com.teumteum.base.R.color.grey_900
-                )
-            )
+        elevation = 0F
+        background = ContextCompat.getDrawable(
+            context,
+            R.drawable.shape_rect12_elevation_level01_outline_level03
         )
-        radius = 12.dpToPx(context).toFloat()
         layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
     }
 
@@ -69,15 +65,24 @@ class FrontCardView : CardView {
      * 커스텀뷰의 속성 값을 xml에 입력한 값으로 초기화
      */
     private fun applyXmlAttributes(context: Context, attrs: AttributeSet?) {
-        context.theme.obtainStyledAttributes(attrs, com.teumteum.base.R.styleable.CardFrontView, 0, 0).apply {
+        context.theme.obtainStyledAttributes(
+            attrs,
+            com.teumteum.base.R.styleable.CardFrontView,
+            0,
+            0
+        ).apply {
             try {
-                frontCard.name = getString(com.teumteum.base.R.styleable.CardFrontView_name) ?: ""
-                frontCard.company = getString(com.teumteum.base.R.styleable.CardFrontView_company) ?: ""
-                frontCard.job = getString(com.teumteum.base.R.styleable.CardFrontView_job) ?: ""
-                frontCard.level = getString(com.teumteum.base.R.styleable.CardFrontView_level) ?: ""
-                frontCard.area = getString(com.teumteum.base.R.styleable.CardFrontView_area) ?: ""
-                frontCard.mbti = getString(com.teumteum.base.R.styleable.CardFrontView_mbti) ?: ""
-                frontCard.characterResId = getResourceId(com.teumteum.base.R.styleable.CardFrontView_image, 0)
+                with(frontCard) {
+                    name = getString(com.teumteum.base.R.styleable.CardFrontView_name) ?: ""
+                    company = getString(com.teumteum.base.R.styleable.CardFrontView_company) ?: ""
+                    job = getString(com.teumteum.base.R.styleable.CardFrontView_job) ?: ""
+                    level = getString(com.teumteum.base.R.styleable.CardFrontView_level) ?: ""
+                    area = getString(com.teumteum.base.R.styleable.CardFrontView_area) ?: ""
+                    mbti = getString(com.teumteum.base.R.styleable.CardFrontView_mbti) ?: ""
+                    characterResId = getResourceId(com.teumteum.base.R.styleable.CardFrontView_characterImage, 0)
+                    isModify = getBoolean(com.teumteum.base.R.styleable.CardFrontView_isModify, false)
+                    isModifyDetail = getBoolean(com.teumteum.base.R.styleable.CardFrontView_isModifyDetail, false)
+                }
             } finally {
                 recycle()
             }
@@ -92,17 +97,29 @@ class FrontCardView : CardView {
         setTextView(tvLevel, frontCard.level)
         setTextView(tvArea, frontCard.area)
         setTextView(tvMbti, frontCard.mbti)
-        setImageViewResource(tvCharacter, frontCard.characterResId)
+
+        val ivFloatVisibility = if (frontCard.isModify == true) View.VISIBLE else View.INVISIBLE
+        val ivEditVisibility = if (frontCard.isModifyDetail == true) View.VISIBLE else View.INVISIBLE
+
+        // 이미지 뷰 프로퍼티 설정을 위한 공통 함수 호출
+        setImageViewProperties(ivFloat, ivFloatVisibility, frontCard.floatResId)
+        setImageViewProperties(ivEditName, ivEditVisibility, frontCard.editNameResId)
+        setImageViewProperties(ivEditCompany, ivEditVisibility, frontCard.editCompanyResId)
+        setImageViewProperties(ivEditJob, ivEditVisibility, frontCard.editJobResId)
+        setImageViewProperties(ivEditArea, ivEditVisibility, frontCard.editAreaResId)
+    }
+
+    private fun setImageViewProperties(viewId: Int, visibility: Int, resId: Int?) {
+        val imageView = findViewById<ImageView>(viewId)
+        imageView?.let {
+            it.visibility = visibility
+            resId?.let { imageResId -> it.setImageResource(imageResId) }
+        }
     }
 
     private fun setTextView(viewId: Int, text: String) {
         val textView = findViewById<TextView>(viewId)
         textView?.text = text
-    }
-
-    private fun setImageViewResource(viewId: Int, resId: Int) {
-        val imageView = findViewById<ImageView>(viewId)
-        imageView?.setImageResource(resId)
     }
 
     /**
@@ -117,12 +134,12 @@ class FrontCardView : CardView {
             context,
             id = tvName,
             text = context.getString(R.string.front_card_name),
-            textColor = com.teumteum.base.R.color.grey_50,
+            textColor = com.teumteum.base.R.color.text_headline_primary,
             textSizeSp = 30f,
             fontFamily = com.teumteum.base.R.font.pretendard_bold,
             lineHeightDp = 36,
-            topToTopOf = matchParent,
-            startToStartOf = matchParent,
+            topToTopOf = layoutParent,
+            startToStartOf = layoutParent,
             marginTop = 40,
             marginStart = 32
         )
@@ -130,7 +147,7 @@ class FrontCardView : CardView {
             context,
             id = tvCompany,
             text = context.getString(R.string.front_card_company),
-            textColor = com.teumteum.base.R.color.grey_400,
+            textColor = com.teumteum.base.R.color.text_body_teritary,
             textSizeSp = 16f,
             fontFamily = com.teumteum.base.R.font.pretendard_semibold,
             lineHeightDp = 22,
@@ -142,7 +159,7 @@ class FrontCardView : CardView {
             context,
             id = tvJob,
             text = context.getString(R.string.front_card_job),
-            textColor = com.teumteum.base.R.color.grey_50,
+            textColor = com.teumteum.base.R.color.text_headline_primary,
             textSizeSp = 18f,
             fontFamily = com.teumteum.base.R.font.pretendard_bold,
             lineHeightDp = 24,
@@ -154,7 +171,7 @@ class FrontCardView : CardView {
             context,
             id = tvLevel,
             text = context.getString(R.string.front_card_level),
-            textColor = com.teumteum.base.R.color.grey_300,
+            textColor = com.teumteum.base.R.color.text_body_secondary,
             textSizeSp = 12f,
             fontFamily = com.teumteum.base.R.font.pretendard_regular,
             lineHeightDp = 18,
@@ -165,13 +182,13 @@ class FrontCardView : CardView {
             paddingBottom = 2,
             startToStartOf = tvName,
             topToBottomOf = tvJob,
-            background = R.drawable.shape_rect4_grey_800
+            background = R.drawable.shape_rect4_elevation_level02
         )
         addTextView(
             context,
             id = tvArea,
             text = context.getString(R.string.front_card_area),
-            textColor = com.teumteum.base.R.color.grey_400,
+            textColor = com.teumteum.base.R.color.text_body_teritary,
             textSizeSp = 12f,
             fontFamily = com.teumteum.base.R.font.pretendard_regular,
             lineHeightDp = 18,
@@ -183,18 +200,65 @@ class FrontCardView : CardView {
             context,
             id = tvMbti,
             text = context.getString(R.string.front_card_mbti),
-            textColor = com.teumteum.base.R.color.grey_50,
+            textColor = com.teumteum.base.R.color.text_headline_primary,
             textSizeSp = 20f,
             fontFamily = com.teumteum.base.R.font.pretendard_bold,
             lineHeightDp = 28,
             marginBottom = 32,
             startToStartOf = tvName,
-            bottomToBottomOf = matchParent
+            bottomToBottomOf = layoutParent
         )
         addImageView(
             context,
-            id = tvCharacter,
-            drawableRes = R.drawable.ic_card_penguin
+            id = ivCharacter,
+            drawableRes = R.drawable.ic_card_penguin,
+            bottomToBottomOf = layoutParent,
+            endToEndOf = layoutParent
+        )
+        addImageView(
+            context,
+            id = ivFloat,
+            drawableRes = R.drawable.ic_card_float,
+            bottomToBottomOf = layoutParent,
+            endToEndOf = layoutParent,
+            marginBottom = 32,
+            marginEnd = 24
+        )
+        addImageView( //todo - 하나의 id값으로 일괄 관리 가능 여부 확인
+            context,
+            id = ivEditName,
+            drawableRes = R.drawable.ic_card_edit,
+            startToEndOf = tvName,
+            topToTopOf = tvName,
+            bottomToBottomOf = tvName,
+            marginStart = 4
+        )
+        addImageView(
+            context,
+            id = ivEditCompany,
+            drawableRes = R.drawable.ic_card_edit,
+            startToEndOf = tvCompany,
+            topToTopOf = tvCompany,
+            bottomToBottomOf = tvCompany,
+            marginStart = 4
+        )
+        addImageView(
+            context,
+            id = ivEditJob,
+            drawableRes = R.drawable.ic_card_edit,
+            startToEndOf = tvJob,
+            topToTopOf = tvJob,
+            bottomToBottomOf = tvJob,
+            marginStart = 4
+        )
+        addImageView(
+            context,
+            id = ivEditArea,
+            drawableRes = R.drawable.ic_card_edit,
+            startToEndOf = tvArea,
+            topToTopOf = tvArea,
+            bottomToBottomOf = tvArea,
+            marginStart = 4
         )
     }
 
@@ -261,15 +325,50 @@ class FrontCardView : CardView {
         addView(textView)
     }
 
-    private fun ConstraintLayout.addImageView(context: Context, id: Int, drawableRes: Int) {
+    private fun ConstraintLayout.addImageView(
+        context: Context, id: Int, drawableRes: Int,
+        marginTop: Int = 0,
+        marginBottom: Int = 0,
+        marginStart: Int = 0,
+        marginEnd: Int = 0,
+        paddingStart: Int = 0,
+        paddingEnd: Int = 0,
+        paddingTop: Int = 0,
+        paddingBottom: Int = 0,
+        topToTopOf: Int? = null,
+        topToBottomOf: Int? = null,
+        bottomToTopOf: Int? = null,
+        bottomToBottomOf: Int? = null,
+        startToStartOf: Int? = null,
+        startToEndOf: Int? = null,
+        endToEndOf: Int? = null,
+        endToStartOf: Int? = null
+    ) {
         val imageView = ImageView(context).apply {
             this.id = id
             layoutParams =
                 ConstraintLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
                     .apply {
-                        bottomToBottom = matchParent
-                        endToEnd = matchParent
+                        topToTopOf?.let { topToTop = it }
+                        topToBottomOf?.let { topToBottom = it }
+                        bottomToTopOf?.let { bottomToTop = it }
+                        bottomToBottomOf?.let { bottomToBottom = it }
+                        startToStartOf?.let { startToStart = it }
+                        startToEndOf?.let { startToEnd = it }
+                        endToEndOf?.let { endToEnd = it }
+                        endToStartOf?.let { endToStart = it }
+
+                        this.topMargin = marginTop.dpToPx(context)
+                        this.bottomMargin = marginBottom.dpToPx(context)
+                        this.marginStart = marginStart.dpToPx(context)
+                        this.marginEnd = marginEnd.dpToPx(context)
                     }
+            setPadding(
+                paddingStart.dpToPx(context),
+                paddingTop.dpToPx(context),
+                paddingEnd.dpToPx(context),
+                paddingBottom.dpToPx(context)
+            )
             setImageResource(drawableRes)
         }
         addView(imageView)
@@ -283,6 +382,11 @@ class FrontCardView : CardView {
         const val tvLevel = 4
         const val tvArea = 5
         const val tvMbti = 6
-        const val tvCharacter = 7
+        const val ivCharacter = 7
+        const val ivFloat = 8
+        const val ivEditName = 9
+        const val ivEditCompany = 10
+        const val ivEditJob = 11
+        const val ivEditArea = 12
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/model/FrontCard.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/model/FrontCard.kt
@@ -9,5 +9,12 @@ data class FrontCard(
     var level: String = "lv.3층",
     var area: String = "선택 지역에 사는",
     var mbti: String = "MBTI",
-    var characterResId: Int = R.drawable.ic_card_penguin
+    var characterResId: Int = R.drawable.ic_card_penguin,
+    var floatResId: Int? = R.drawable.ic_card_float,
+    var editNameResId: Int? = R.drawable.ic_card_edit,
+    var editCompanyResId: Int? = R.drawable.ic_card_edit,
+    var editJobResId: Int? = R.drawable.ic_card_edit,
+    var editAreaResId: Int? = R.drawable.ic_card_edit,
+    var isModify: Boolean? = false,
+    var isModifyDetail: Boolean? = false
 )

--- a/app/src/main/res/drawable-night/ic_card_edit.xml
+++ b/app/src/main/res/drawable-night/ic_card_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M14,6.092L9.908,2L2.667,9.242V13.333H6.758L14,6.092ZM8.517,4.78L9.908,3.389L12.611,6.092L11.22,7.483L8.517,4.78Z"
+      android:fillColor="#F5F5F5"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable-night/ic_card_float.xml
+++ b/app/src/main/res/drawable-night/ic_card_float.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <path
+      android:pathData="M36,32m-32,0a32,32 0,1 1,64 0a32,32 0,1 1,-64 0"
+      android:fillColor="#F5F5F5"/>
+  <path
+      android:pathData="M48.241,25.951L42.113,19.823L26.236,35.7L25.35,41.296L26.906,42.816L32.376,41.816L48.241,25.951ZM28.278,39.854L28.734,36.973L38.602,27.105L40.959,29.462L31.079,39.342L28.278,39.854ZM42.845,27.577L44.47,25.951L42.113,23.594L40.488,25.22L42.845,27.577Z"
+      android:fillColor="#444444"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_card_edit.xml
+++ b/app/src/main/res/drawable/ic_card_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M14,6.092L9.908,2L2.667,9.242V13.333H6.758L14,6.092ZM8.517,4.78L9.908,3.389L12.611,6.092L11.22,7.483L8.517,4.78Z"
+      android:fillColor="#212121"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_card_float.xml
+++ b/app/src/main/res/drawable/ic_card_float.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <path
+      android:pathData="M36,32m-32,0a32,32 0,1 1,64 0a32,32 0,1 1,-64 0"
+      android:fillColor="#444444"/>
+  <path
+      android:pathData="M48.241,25.951L42.113,19.823L26.236,35.7L25.35,41.296L26.906,42.816L32.376,41.816L48.241,25.951ZM28.278,39.854L28.734,36.973L38.602,27.105L40.959,29.462L31.079,39.342L28.278,39.854ZM42.845,27.577L44.47,25.951L42.113,23.594L40.488,25.22L42.845,27.577Z"
+      android:fillColor="#F5F5F5"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/shape_rect12_elevation_level01_outline_level03.xml
+++ b/app/src/main/res/drawable/shape_rect12_elevation_level01_outline_level03.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/elevation_level01" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/outline_level03" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_rect4_background.xml
+++ b/app/src/main/res/drawable/shape_rect4_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/background" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_rect4_elevation_level02.xml
+++ b/app/src/main/res/drawable/shape_rect4_elevation_level02.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/grey_800" />
+    <solid android:color="@color/elevation_level02" />
     <corners android:radius="4dp" />
 </shape>

--- a/app/src/main/res/layout/activity_card_intro.xml
+++ b/app/src/main/res/layout/activity_card_intro.xml
@@ -56,7 +56,7 @@
             app:level="@string/front_card_level"
             app:area="@string/front_card_area"
             app:mbti="@string/front_card_mbti"
-            app:image="@drawable/ic_card_penguin"
+            app:characterImage="@drawable/ic_card_penguin"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_subtitle"

--- a/app/src/main/res/layout/fragment_card_complete.xml
+++ b/app/src/main/res/layout/fragment_card_complete.xml
@@ -52,7 +52,7 @@
             app:level="@string/front_card_level"
             app:area="@string/front_card_area"
             app:mbti="@string/front_card_mbti"
-            app:image="@drawable/ic_card_penguin"
+            app:characterImage="@drawable/ic_card_penguin"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_subtitle"

--- a/app/src/main/res/layout/fragment_card_fix.xml
+++ b/app/src/main/res/layout/fragment_card_fix.xml
@@ -52,7 +52,7 @@
             app:level="@string/front_card_level"
             app:area="@string/front_card_area"
             app:mbti="@string/front_card_mbti"
-            app:image="@drawable/ic_card_penguin"
+            app:characterImage="@drawable/ic_card_penguin"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_subtitle"

--- a/core/base/src/main/res/values/attrs.xml
+++ b/core/base/src/main/res/values/attrs.xml
@@ -92,7 +92,9 @@
         <attr name="level" format="string" />
         <attr name="area" format="string" />
         <attr name="mbti" format="string" />
-        <attr name="image" format="integer" />
+        <attr name="characterImage" format="integer" />
+        <attr name="isModify" format="boolean" />
+        <attr name="isModifyDetail" format="boolean" />
     </declare-styleable>
-    
+
 </resources>


### PR DESCRIPTION
## 📌 개요
- closed #54 

## ✨ 작업 내용
- 카드 앞면 커스텀뷰 UI 디테일 보충
- 기존 커스텀뷰 속성 이름 변경 app:image -> app:characterImage
- 디자인 컴포넌트 이름을 그대로 따라서 속성 추가
- 다크/라이트 모드 적용
- 리팩토링
## ✨ PR 포인트
isModify = true 시 floatting 버튼이 visible 됩니다.
isModifyDetail = true 시 TextView들 옆 연필 아이콘이 visible 됩니다.

- xml 쓰시는 분들은 binding으로 isModify, isModifyDetail 속성값 참조해서 true/false 값 조절하시면 알아서 visibility가 조정됩니다.
- 컴포즈 쓰시는 분들은 getInstance로 뷰 객체 받아올 때 인자로 isModfy, isModifyDetail 값 넣어주시면 됩니다. 기본값은 false(invisible)입니다. 

tvArea 부분 편집 모드 시 디자인 바뀌는 부분은 생각보다 공수가 많이 들어 후작업으로 미뤘습니다.
## 📸 스크린샷/동영상
| 화면 예시 | XML 사용법 |
| :---: | :---: | 
|<img width="400" src="https://github.com/depromeet/TeumTeum-Android/assets/89737271/c21783ea-c090-4956-98b7-aed5c9c41ca6">|<img width="400" src="https://github.com/depromeet/TeumTeum-Android/assets/89737271/d22acee5-825b-4622-8c37-1e9451ef9bfd">|


