### PR TITLE
[FIX/#81] 바텀시트 및 스낵바 수정

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/editCard/EditCardFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/editCard/EditCardFragment.kt
@@ -1,6 +1,5 @@
 package com.teumteum.teumteum.presentation.mypage.editCard
 
-import android.app.ProgressDialog.show
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
@@ -14,7 +13,6 @@ import com.teumteum.teumteum.presentation.MainActivity
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.EditCardViewModel
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.MyPageViewModel
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.SheetEvent
-import com.teumteum.teumteum.presentation.signup.SignUpActivity
 import com.teumteum.teumteum.presentation.signup.modal.AreaModalBottomSheet
 import com.teumteum.teumteum.presentation.signup.modal.MbtiModalBottomSheet
 import com.teumteum.teumteum.presentation.signup.modal.SingleModalBottomSheet
@@ -102,9 +100,9 @@ class EditCardFragment: BindingFragment<FragmentEditCardBinding>(R.layout.fragme
             mbtiBoolean[1] = mbtiCharArray[1] == 'N'
             mbtiBoolean[2] = mbtiCharArray[2] == 'F'
             mbtiBoolean[3] = mbtiCharArray[3] == 'P'
-            mbtiBottomSheet?.setSelectedMbti(mbtiBoolean[0], mbtiBoolean[1], mbtiBoolean[2], mbtiBoolean[3])
+            mbtiBottomSheet?.initSelectedMbti(mbtiBoolean[0], mbtiBoolean[1], mbtiBoolean[2], mbtiBoolean[3])
         }
-        else mbtiBottomSheet?.initMbti()
+        else mbtiBottomSheet?.initDefaultMbti()
     }
 
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/mbti/GetMbtiFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/mbti/GetMbtiFragment.kt
@@ -12,6 +12,7 @@ import com.teumteum.teumteum.presentation.signup.SignUpViewModel
 import com.teumteum.teumteum.presentation.signup.modal.MbtiModalBottomSheet
 import com.teumteum.teumteum.presentation.signup.modal.SingleModalBottomSheet
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class GetMbtiFragment:
     BindingFragment<FragmentGetMbtiBinding>(R.layout.fragment_get_mbti) {
@@ -41,26 +42,31 @@ class GetMbtiFragment:
                 bottomSheet?.setFocusedImageView(ivShow)
                 val mbtiBoolean = BooleanArray(4)
                 val mbtiCharArray = viewModel.mbtiText.value.toCharArray()
-//                reloadLastMbti()
-                bottomSheet?.initMbti()
+//                bottomSheet?.initMbti()
+                reloadLastMbti()
                 bottomSheet?.show(childFragmentManager, SingleModalBottomSheet.TAG)
+                Timber.tag("teum-mbti").d("initBottomSheet called")
+
+
                 ivShow.setImageResource(R.drawable.ic_arrow_up_l)
             }
         }
     }
 
-    /* 지난 mbti 선택에 따라 버튼 활성화 유지 -> 수정 필요 */
+    /* 지난 mbti 선택에 따라 버튼 활성화 유지 -> 수정 완료 */
     private fun reloadLastMbti() {
         val mbtiBoolean = BooleanArray(4)
         val mbtiCharArray = viewModel.mbtiText.value.toCharArray()
+        Timber.tag("teum-mbti").d(mbtiCharArray.concatToString())
         if (mbtiCharArray.size == 4) {
             mbtiBoolean[0] = mbtiCharArray[0] == 'E'
             mbtiBoolean[1] = mbtiCharArray[1] == 'N'
             mbtiBoolean[2] = mbtiCharArray[2] == 'F'
             mbtiBoolean[3] = mbtiCharArray[3] == 'P'
-            bottomSheet?.setSelectedMbti(mbtiBoolean[0], mbtiBoolean[1], mbtiBoolean[2], mbtiBoolean[3])
+            Timber.tag("teum-mbti").d("${mbtiBoolean[0]} ${mbtiBoolean[1]} ${mbtiBoolean[2]} ${mbtiBoolean[3]}")
+            bottomSheet?.initSelectedMbti(mbtiBoolean[0], mbtiBoolean[1], mbtiBoolean[2], mbtiBoolean[3])
         }
-        else bottomSheet?.initMbti()
+        else bottomSheet?.initDefaultMbti()
     }
 
     private fun checkValidInput() {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/mbti/GetMbtiFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/mbti/GetMbtiFragment.kt
@@ -40,14 +40,8 @@ class GetMbtiFragment:
         with(binding) {
             llStatus.setOnClickListener {
                 bottomSheet?.setFocusedImageView(ivShow)
-                val mbtiBoolean = BooleanArray(4)
-                val mbtiCharArray = viewModel.mbtiText.value.toCharArray()
-//                bottomSheet?.initMbti()
                 reloadLastMbti()
                 bottomSheet?.show(childFragmentManager, SingleModalBottomSheet.TAG)
-                Timber.tag("teum-mbti").d("initBottomSheet called")
-
-
                 ivShow.setImageResource(R.drawable.ic_arrow_up_l)
             }
         }
@@ -57,13 +51,11 @@ class GetMbtiFragment:
     private fun reloadLastMbti() {
         val mbtiBoolean = BooleanArray(4)
         val mbtiCharArray = viewModel.mbtiText.value.toCharArray()
-        Timber.tag("teum-mbti").d(mbtiCharArray.concatToString())
         if (mbtiCharArray.size == 4) {
             mbtiBoolean[0] = mbtiCharArray[0] == 'E'
             mbtiBoolean[1] = mbtiCharArray[1] == 'N'
             mbtiBoolean[2] = mbtiCharArray[2] == 'F'
             mbtiBoolean[3] = mbtiCharArray[3] == 'P'
-            Timber.tag("teum-mbti").d("${mbtiBoolean[0]} ${mbtiBoolean[1]} ${mbtiBoolean[2]} ${mbtiBoolean[3]}")
             bottomSheet?.initSelectedMbti(mbtiBoolean[0], mbtiBoolean[1], mbtiBoolean[2], mbtiBoolean[3])
         }
         else bottomSheet?.initDefaultMbti()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/modal/MbtiModalBottomSheet.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/modal/MbtiModalBottomSheet.kt
@@ -2,7 +2,6 @@ package com.teumteum.teumteum.presentation.signup.modal
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,12 +52,10 @@ class MbtiModalBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun setFeeler(feeler: Boolean) {
-        Log.d("teum-mbti", "setFeeler: $feeler")
         with(binding) {
             btnF.isSelected = feeler
             btnT.isSelected = !feeler
         }
-        Log.d("teum-mbti", "check: ${binding.btnF.isSelected} ${binding.btnT.isSelected}")
         mbtiText[2] = if (feeler) 'F' else 'T'
     }
 
@@ -70,7 +67,7 @@ class MbtiModalBottomSheet : BottomSheetDialogFragment() {
         mbtiText[3] = if (perceiver) 'P' else 'J'
     }
 
-    fun initMbti() {
+    fun initDefaultMbti() {
         mbtiText = "xxxx".toCharArray()
     }
 
@@ -111,6 +108,27 @@ class MbtiModalBottomSheet : BottomSheetDialogFragment() {
                 setPerceiver(false)
                 checkValid()
             }
+
+            when (mbtiText[0]) {
+                'E' -> btnE.callOnClick()
+                'I' -> btnI.callOnClick()
+                else -> {}
+            }
+            when (mbtiText[1]) {
+                'N' -> btnN.callOnClick()
+                'S' -> btnS.callOnClick()
+                else -> {}
+            }
+            when (mbtiText[2]) {
+                'F' -> btnF.callOnClick()
+                'T' -> btnT.callOnClick()
+                else -> {}
+            }
+            when (mbtiText[3]) {
+                'P' -> btnP.callOnClick()
+                'J' -> btnJ.callOnClick()
+                else -> {}
+            }
         }
     }
 
@@ -122,15 +140,11 @@ class MbtiModalBottomSheet : BottomSheetDialogFragment() {
         focusedShowImageView = iv
     }
 
-    fun setSelectedMbti(extrovert: Boolean, intuitive: Boolean, feeler: Boolean, perceiver: Boolean) {
-        binding.root.post {
-            with(binding) {
-                if (extrovert) btnE.callOnClick() else btnI.callOnClick()
-                if (intuitive) btnN.callOnClick() else btnS.callOnClick()
-                if (feeler) btnF.callOnClick() else btnT.callOnClick()
-                if (perceiver) btnP.callOnClick() else btnJ.callOnClick()
-            }
-        }
+    fun initSelectedMbti(extrovert: Boolean, intuitive: Boolean, feeler: Boolean, perceiver: Boolean) {
+        mbtiText[0] = if (extrovert) 'E' else 'I'
+        mbtiText[1] = if (intuitive) 'N' else 'S'
+        mbtiText[2] = if (feeler) 'F' else 'T'
+        mbtiText[3] = if (perceiver) 'P' else 'J'
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/core/base/src/main/java/com/teumteum/base/component/toast/DefaultToast.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/toast/DefaultToast.kt
@@ -1,0 +1,29 @@
+package com.teumteum.base.component.toast
+
+import android.content.Context
+import android.content.res.Resources
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.widget.Toast
+import androidx.databinding.DataBindingUtil
+import com.teumteum.base.R
+import com.teumteum.base.databinding.ToastDefaultBinding
+
+object DefaultToast {
+
+    fun createToast(context: Context, message: String): Toast? {
+        val inflater = LayoutInflater.from(context)
+        val binding: ToastDefaultBinding =
+            DataBindingUtil.inflate(inflater, R.layout.toast_default, null, false)
+
+        binding.tvSnackbarDefault.text = message
+
+        return Toast(context).apply {
+            setGravity(Gravity.FILL_HORIZONTAL or Gravity.BOTTOM, 0, 20.toPx())
+            duration = Toast.LENGTH_SHORT
+            view = binding.root
+        }
+    }
+
+    private fun Int.toPx(): Int = (this * Resources.getSystem().displayMetrics.density).toInt()
+}

--- a/core/base/src/main/java/com/teumteum/base/util/extension/ContextExtension.kt
+++ b/core/base/src/main/java/com/teumteum/base/util/extension/ContextExtension.kt
@@ -9,6 +9,7 @@ import androidx.annotation.StringRes
 import com.google.android.material.snackbar.Snackbar
 import com.teumteum.base.component.snackbar.ButtonSnackBar
 import com.teumteum.base.component.snackbar.DefaultSnackBar
+import com.teumteum.base.component.toast.DefaultToast
 
 fun Context.toast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
@@ -16,6 +17,10 @@ fun Context.toast(message: String) {
 
 fun Context.longToast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+}
+
+fun Context.defaultToast(message: String) {
+    DefaultToast.createToast(this, message)?.show()
 }
 
 fun Context.snackBar(anchorView: View, message: () -> String) {

--- a/core/base/src/main/res/layout/toast_default.xml
+++ b/core/base/src/main/res/layout/toast_default.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="20dp"
+        >
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:theme="@style/Theme.TeumTeum"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="12dp"
+            android:paddingHorizontal="20dp"
+            android:background="@drawable/shape_rect12_button_default02"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            >
+            <TextView
+                android:id="@+id/tv_snackbar_default"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="@color/text_body_quinary"
+                style="@style/ta.body.1"
+                android:text="텍스트"
+                android:paddingVertical="6dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
 ## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- open #81 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 이전 MBTI가 바텀시트를 다시 오픈했을 때 선택되어 있도록 수정
  - 천재개발자민서쓰를 위한 참고 내용~~
  - GetMbtiFragment > initBottomSheet()와 reloadLastMbti() 활용해주심 됨다
- 스낵바의 뷰 종속성으로 인해 단순 default 메시지는 defaultToast(msg)로 대체

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->