### PR TITLE
[Fix/#104] 다크모드&라이트 모드 설정

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/presentation/MainActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/MainActivity.kt
@@ -21,9 +21,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        this.onBackPressedDispatcher.addCallback(this,
-            CustomBackPressedCallback(this, getString(R.string.alert_back_pressed_finish))
-        )
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.fl_main) as NavHostFragment
         val navController = navHostFragment.navController

--- a/app/src/main/java/com/teumteum/teumteum/presentation/group/GroupListViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/group/GroupListViewModel.kt
@@ -44,7 +44,7 @@ class GroupListViewModel @Inject constructor(
                     }
                     if (!it.first) isPagingFinish = true
                 }.onFailure {
-                    _groupData.value = GroupListUiState.Failure("모임 리스트 서버 통신 싪패")
+                    _groupData.value = GroupListUiState.Failure("모임 리스트 서버 통신 실패")
                 }
         }
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/group/join/GroupDetailActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/group/join/GroupDetailActivity.kt
@@ -6,16 +6,23 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.teumteum.base.BindingActivity
 import com.teumteum.base.component.compose.theme.ColorPalette_Dark
 import com.teumteum.base.component.compose.theme.ColorPalette_Light
 import com.teumteum.base.component.compose.theme.TmtmColorPalette
+import com.teumteum.base.util.extension.defaultToast
 import com.teumteum.base.util.extension.longExtra
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ActivityGroupDetailBinding
 import com.teumteum.teumteum.presentation.moim.MoimConfirm
 import com.teumteum.teumteum.presentation.moim.MoimViewModel
+import com.teumteum.teumteum.presentation.moim.ScreenState
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
 
 @AndroidEntryPoint
 class GroupDetailActivity :
@@ -27,11 +34,27 @@ class GroupDetailActivity :
         super.onCreate(savedInstanceState)
         binding.composeGroup.setContent {
             CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
-                MoimConfirm(viewModel = viewModel, activity = this, isJoinView = true)
+                MoimConfirm(viewModel = viewModel, activity = this, isJoinView = true, meetingId = meetingId)
             }
         }
-
+        observe()
         initView()
+    }
+
+    private fun observe() {
+        viewModel.screenState.flowWithLifecycle(lifecycle)
+            .onEach {
+                when(it){
+                    ScreenState.Failure -> { this@GroupDetailActivity?.defaultToast(getString(R.string.moim_alert_message_failure)) }
+                    ScreenState.Server -> { this@GroupDetailActivity?.defaultToast(getString(R.string.moim_alert_message_server)) }
+                    ScreenState.CancelSuccess -> {
+                        this@GroupDetailActivity?.defaultToast(getString(R.string.moim_alert_message_success))
+                        initView()
+                    }
+                    else -> {}
+                }
+            }
+            .launchIn(lifecycleScope)
     }
 
     private fun initView() {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/group/join/GroupDetailActivity.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/group/join/GroupDetailActivity.kt
@@ -4,7 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import com.teumteum.base.BindingActivity
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.base.util.extension.longExtra
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ActivityGroupDetailBinding
@@ -21,7 +26,9 @@ class GroupDetailActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.composeGroup.setContent {
-            MoimConfirm(viewModel = viewModel, activity = this, isJoinView = true)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                MoimConfirm(viewModel = viewModel, activity = this, isJoinView = true)
+            }
         }
 
         initView()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/home/HomeFragment.kt
@@ -24,6 +24,7 @@ import com.teumteum.teumteum.presentation.group.GroupListUiState
 import com.teumteum.teumteum.presentation.group.GroupListViewModel
 import com.teumteum.teumteum.presentation.group.join.GroupDetailActivity
 import com.teumteum.teumteum.presentation.group.search.SearchActivity
+import com.teumteum.teumteum.util.callback.CustomBackPressedCallback
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -33,6 +34,8 @@ class HomeFragment :
     BindingFragment<FragmentHomeBinding>(R.layout.fragment_home), AppBarLayout {
     private val viewModel by viewModels<GroupListViewModel>()
     private var adapter: GroupListAdapter? = null
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -49,7 +52,6 @@ class HomeFragment :
     override fun initAppBarLayout() {
         setAppBarHeight(48)
         setAppBarBackgroundColor(com.teumteum.base.R.color.background)
-
         addMenuToLeft(
             AppBarMenu.IconStyle(
                 resourceId = R.drawable.ic_logo_title,
@@ -59,6 +61,9 @@ class HomeFragment :
                 }
             )
         )
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, CustomBackPressedCallback(requireActivity(), getString(R.string.alert_back_pressed_finish)))
+
         addMenuToRight(
             AppBarMenu.IconStyle(
                 resourceId = R.drawable.ic_search,

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimAddress.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimAddress.kt
@@ -135,6 +135,7 @@ fun MoimAddressInputField(
         onValueChange = { newText ->
             viewModel.updateDetailAddress(newText)
         },
+        singleLine = true,
         colors = TextFieldDefaults.outlinedTextFieldColors(
             textColor = TmtmColorPalette.current.color_text_body_primary,
             focusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimAddress.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimAddress.kt
@@ -141,7 +141,8 @@ fun MoimAddressInputField(
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
@@ -117,7 +117,10 @@ fun MoimConfirm(
         if (isJoinView) ""
         else if (meetingId != null && meetingId > 0) ""
         else stringResource(id = R.string.moim_confirm_appbar),
-        onClick = { onClick() }
+        onClick = {
+            if(isJoinView) { onClick() }
+            else { viewModel.goPreviousScreen() }
+            }
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
@@ -117,59 +119,69 @@ fun MoimConfirm(
         else stringResource(id = R.string.moim_confirm_appbar),
         onClick = { onClick() }
     ) {
-        val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(color = TmtmColorPalette.current.color_background)
-                .verticalScroll(scrollState)
         ) {
-            MoimPhotoPager(viewModel)
-            MoimConfirmInfo(viewModel)
-            TmMarginVerticalSpacer(size = 32)
-            TeumDividerThick(int = 8)
-            TmMarginVerticalSpacer(size = 20)
-            MoimHostRow(viewModel)
-            TmMarginVerticalSpacer(size = 20)
-            if (isJoinView) {
-                TeumDividerHorizontalThick(int = 1, 20)
-                TmMarginVerticalSpacer(size = 20)
-                MoimJoinUserRow(viewModel) {
-                    activity.startActivity(JoinFriendListActivity.getIntent(activity, Json.encodeToString(it)))
-                    (activity as? BindingActivity<*>)?.openActivitySlideAnimation()
-                }
-                TmMarginVerticalSpacer(size = 20)
-            }
-            TeumDividerThick(int = 8)
-            MoimConfirmIntroColumn(viewModel)
-            Spacer(modifier = Modifier.weight(1f))
-            TeumDivider()
-            if (isJoinView) {
-                if (meetingId != null && meetingId > 0) {
-                    MoimCancelBtn(
-                        viewModel = viewModel,
-                        onJoinGroupClick = { viewModel.cancelMeeting(it)})
-                } else {
-                    MoimJoinBtn(viewModel = viewModel) {
-                        activity.startActivity(
-                            GroupMeetCheckActivity.getIntent(activity, it)
-                        )
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                    item {
+                        MoimPhotoPager(viewModel)
+                        MoimConfirmInfo(viewModel)
+                        TmMarginVerticalSpacer(size = 32)
+                        TeumDividerThick(int = 8)
+                        TmMarginVerticalSpacer(size = 20)
+                        MoimHostRow(viewModel)
+                        TmMarginVerticalSpacer(size = 20)
+                        if (isJoinView) {
+                            TeumDividerHorizontalThick(int = 1, 20)
+                            TmMarginVerticalSpacer(size = 20)
+                            MoimJoinUserRow(viewModel) {
+                                activity.startActivity(JoinFriendListActivity.getIntent(activity, Json.encodeToString(it)))
+                                (activity as? BindingActivity<*>)?.openActivitySlideAnimation()
+                            }
+                            TmMarginVerticalSpacer(size = 20)
+                        }
+                        TeumDividerThick(int = 8)
+                        MoimConfirmIntroColumn(viewModel)
                     }
                 }
-            } else {
-                MoimCreateBtn(text = stringResource(id = R.string.moim_confirm_btn), viewModel = viewModel)
-                TmMarginVerticalSpacer(size = 24)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 10.dp)
+            ) {
+                if (isJoinView) {
+                    if (meetingId != null && meetingId > 0) {
+                        TeumDivider()
+                        MoimCancelBtn(
+                            viewModel = viewModel,
+                            onJoinGroupClick = { viewModel.cancelMeeting(it)})
+                        TmMarginVerticalSpacer(size = 24)
+                    } else {
+                        TeumDivider()
+                        MoimJoinBtn(viewModel = viewModel) {
+                            activity.startActivity(
+                                GroupMeetCheckActivity.getIntent(activity, it)
+                            )
+                        }
+                        TmMarginVerticalSpacer(size = 24)
+                    }
+                } else {
+                    TeumDivider()
+                    MoimCreateBtn(text = stringResource(id = R.string.moim_confirm_btn), viewModel = viewModel)
+                    TmMarginVerticalSpacer(size = 24)
+                }
             }
         }
     }
     BackHandler {
-        // Handle the back button press
-        activity.finish()
-        (activity as? BindingActivity<*>)?.closeActivitySlideAnimation()
+        if(isJoinView) {
+            activity.finish()
+            (activity as? BindingActivity<*>)?.closeActivitySlideAnimation()
+        }
     }
 }
-
-
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
@@ -189,9 +201,10 @@ fun MoimPhotoPager(viewModel : MoimViewModel) {
                 painter = rememberAsyncImagePainter(uri),
                 contentDescription = null,
                 modifier = Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 276.dp)
                     .clipToBounds(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.FillWidth
             )
         }
         if (imageUri.size > 1) {
@@ -215,10 +228,12 @@ fun MoimConfirmInfo(viewModel: MoimViewModel) {
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
+            .background(color = TmtmColorPalette.current.color_background)
             .padding(horizontal = 20.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top
     ) {
+        TmMarginVerticalSpacer(size = 32)
         Row(modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight(),

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
@@ -157,7 +157,7 @@ fun MoimConfirm(
                     }
                 }
             } else {
-                MoimCreateBtn(text = stringResource(id = R.string.moim_next_btn), viewModel = viewModel)
+                MoimCreateBtn(text = stringResource(id = R.string.moim_confirm_btn), viewModel = viewModel)
                 TmMarginVerticalSpacer(size = 24)
             }
         }
@@ -190,7 +190,8 @@ fun MoimPhotoPager(viewModel : MoimViewModel) {
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxSize()
-                    .clipToBounds()
+                    .clipToBounds(),
+                contentScale = ContentScale.Crop
             )
         }
         if (imageUri.size > 1) {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimConfirm.kt
@@ -1,6 +1,7 @@
 package com.teumteum.teumteum.presentation.moim
 
 import android.app.Activity
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -83,6 +84,7 @@ fun MoimConfirm(
 ) {
     val showDialog = remember { mutableStateOf(false) }
     val screenState by viewModel.screenState.collectAsState()
+    val isJoined by viewModel.isUserJoined.collectAsState()
 
     LaunchedEffect(key1 = screenState) {
         if (screenState == ScreenState.Cancel) {
@@ -156,19 +158,38 @@ fun MoimConfirm(
             ) {
                 if (isJoinView) {
                     if (meetingId != null && meetingId > 0) {
-                        TeumDivider()
-                        MoimCancelBtn(
-                            viewModel = viewModel,
-                            onJoinGroupClick = { viewModel.cancelMeeting(it)})
-                        TmMarginVerticalSpacer(size = 24)
-                    } else {
-                        TeumDivider()
-                        MoimJoinBtn(viewModel = viewModel) {
-                            activity.startActivity(
-                                GroupMeetCheckActivity.getIntent(activity, it)
-                            )
+                        //meeting Id가 argument로 있는데, 참여중인 경우
+                        if(isJoined) {
+                            TeumDivider()
+                            MoimCancelBtn(
+                                viewModel = viewModel
+                            ) {
+                                if (meetingId != null) { viewModel.cancelMeeting(it) }
+                                else { viewModel.updateSheetEvent(ScreenState.Failure) }
+                            }
+                            TmMarginVerticalSpacer(size = 24)
                         }
-                        TmMarginVerticalSpacer(size = 24)
+                        //meeting Id가 argument로 있는데, 참여 중이지 않은 경우
+                        else {
+                            TeumDivider()
+                            MoimJoinBtn(viewModel = viewModel) {
+                                activity.startActivity(
+                                    GroupMeetCheckActivity.getIntent(activity, it)
+                                )
+                            }
+                            TmMarginVerticalSpacer(size = 24)
+                        }
+                    } else {
+                        //meeting Id가 argument로 없음, 참여중이지 않은경우(moimCreate)
+                        if(isJoined == false) {
+                            TeumDivider()
+                            MoimJoinBtn(viewModel = viewModel) {
+                                activity.startActivity(
+                                    GroupMeetCheckActivity.getIntent(activity, it)
+                                )
+                            }
+                            TmMarginVerticalSpacer(size = 24)
+                        }
                     }
                 } else {
                     TeumDivider()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateName.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateName.kt
@@ -62,6 +62,7 @@ fun MoimNameTextField(viewModel: MoimViewModel, placeHolder: String) {
 
     OutlinedTextField(
         value = text,
+        singleLine = true,
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight(),

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateName.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateName.kt
@@ -77,7 +77,8 @@ fun MoimNameTextField(viewModel: MoimViewModel, placeHolder: String) {
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateTopic.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateTopic.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -75,7 +76,7 @@ fun MoimCreateBtn(
     navController: NavController? = null
 ) {
     val screenState by viewModel.screenState.collectAsState()
-    val context = LocalContext.current
+    var lastClickTime by remember { mutableStateOf(0L) }
 
     val buttonColors = if (isEnabled) TmtmColorPalette.current.color_button_active else TmtmColorPalette.current.color_button_disabled
     val textColors = if(isEnabled) TmtmColorPalette.current.color_text_button_primary_default else TmtmColorPalette.current.color_text_button_primary_disabled
@@ -86,14 +87,18 @@ fun MoimCreateBtn(
             .padding(horizontal = 20.dp, vertical = 10.dp),
         enabled = isEnabled,
         onClick = {
-            if (screenState == ScreenState.Create) {
-                viewModel.createMoim()
-                Log.d("screenState", screenState.toString())
-            } else if (screenState == ScreenState.Finish) {
-                navController?.navigate(R.id.fragment_home)
-            }
-            else {
-            viewModel.goToNextScreen() }},
+            val currentClickTime = System.currentTimeMillis()
+            val gapTime = currentClickTime - lastClickTime
+
+            if(gapTime > 1000) {
+                if (screenState == ScreenState.Create) {
+                    viewModel.createMoim()
+                } else if (screenState == ScreenState.Success) {
+                    navController?.navigate(R.id.fragment_home)
+                }
+                else {
+                    viewModel.goToNextScreen() }}
+            },
         colors = ButtonDefaults.buttonColors(containerColor = buttonColors),
         shape = RoundedCornerShape(size = 4.dp)
     ) {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateTopic.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimCreateTopic.kt
@@ -44,6 +44,7 @@ import com.teumteum.base.component.compose.TmScaffold
 import com.teumteum.teumteum.R
 import com.teumteum.base.component.compose.theme.TmTypo
 import com.teumteum.base.component.compose.theme.TmtmColorPalette
+import kotlinx.coroutines.delay
 
 @Composable
 fun MoimCreateTopic(viewModel: MoimViewModel, onClick: ()->Unit) {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimDateTime.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimDateTime.kt
@@ -137,6 +137,7 @@ fun MoimDateInputField(
                 }
             }
         },
+        singleLine = true,
         colors = TextFieldDefaults.outlinedTextFieldColors(
             textColor = TmtmColorPalette.current.color_text_body_primary,
             focusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimDateTime.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimDateTime.kt
@@ -143,7 +143,8 @@ fun MoimDateInputField(
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFinish.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFinish.kt
@@ -31,11 +31,11 @@ fun MoimFinish(viewModel: MoimViewModel, navController: NavController) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = TmtmColorPalette.current.GreyWhite),
+                .background(color = TmtmColorPalette.current.color_background),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
         ) {
-            TmMarginVerticalSpacer(size = 198)
+            TmMarginVerticalSpacer(size = 218)
             MoimFinishColumn()
             Spacer(modifier = Modifier.weight(1f))
             TeumDivider()
@@ -62,9 +62,11 @@ fun MoimFinishColumn() {
             painterResource(id = R.drawable.ic_suprise),
             contentDescription = null
         )
+        TmMarginVerticalSpacer(size = 16)
         Text(
             text = stringResource(R.string.moim_finish),
             style = TmTypo.current.HeadLine5,
+            color = TmtmColorPalette.current.color_text_headline_primary
         )
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFinish.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFinish.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -25,8 +26,8 @@ import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 
 @Composable
-fun MoimFinish(viewModel: MoimViewModel, onClick: ()->Unit, navController: NavController) {
-    TmScaffold(onClick = {onClick()}) {
+fun MoimFinish(viewModel: MoimViewModel, navController: NavController) {
+    TmScaffold(onClick = { viewModel.goPreviousScreen()}) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -36,9 +37,10 @@ fun MoimFinish(viewModel: MoimViewModel, onClick: ()->Unit, navController: NavCo
         ) {
             TmMarginVerticalSpacer(size = 198)
             MoimFinishColumn()
+            Spacer(modifier = Modifier.weight(1f))
             TeumDivider()
             MoimCreateBtn(
-                text = stringResource(id = R.string.moim_next_btn),
+                text = stringResource(id = R.string.moim_finish_btn),
                 viewModel = viewModel,
                 navController=  navController
             )
@@ -52,7 +54,9 @@ fun MoimFinishColumn() {
     Column(modifier = Modifier
         .fillMaxWidth()
         .wrapContentHeight()
-        .padding(horizontal = 20.dp)
+        .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
     ) {
         Image(
             painterResource(id = R.drawable.ic_suprise),

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.fragment.app.activityViewModels
@@ -12,6 +14,9 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.base.util.extension.defaultToast
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentMoimBinding
@@ -53,30 +58,42 @@ class MoimFragment :
         }
 
         binding.composeMoim.setContent {
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
                 val screenState by viewModel.screenState.collectAsState()
                 when (screenState) {
                     ScreenState.Topic -> MoimCreateTopic(viewModel) { goFrontScreen() }
                     ScreenState.Name -> MoimCreateName(viewModel) { goFrontScreen() }
-                    ScreenState.Introduce -> MoimIntroduce(viewModel) { goFrontScreen()}
-                    ScreenState.DateTime -> MoimDateTime(viewModel) { goFrontScreen()}
-                    ScreenState.Address -> MoimAddress(viewModel, navController) { goFrontScreen()}
-                    ScreenState.People -> MoimPeople(viewModel) { goFrontScreen()}
+                    ScreenState.Introduce -> MoimIntroduce(viewModel) { goFrontScreen() }
+                    ScreenState.DateTime -> MoimDateTime(viewModel) { goFrontScreen() }
+                    ScreenState.Address -> MoimAddress(viewModel, navController) { goFrontScreen() }
+                    ScreenState.People -> MoimPeople(viewModel) { goFrontScreen() }
                     ScreenState.Create -> {
                         binding.progressBar.visibility = View.GONE
                         viewModel.getUserId()
-                        MoimConfirm(viewModel, requireActivity(),false) { goFrontScreen()}
+                        MoimConfirm(viewModel, requireActivity(), false) { goFrontScreen() }
                     }
+
                     ScreenState.CancelInit, ScreenState.Cancel -> {
                         binding.progressBar.visibility = View.GONE
-                        MoimConfirm(viewModel, requireActivity(),true, meetingId) {navController.popBackStack()}
+                        MoimConfirm(
+                            viewModel,
+                            requireActivity(),
+                            true,
+                            meetingId
+                        ) { navController.popBackStack() }
                     }
-                    ScreenState.Success -> MoimFinish(viewModel = viewModel, onClick = {goFrontScreen()} ,navController = navController)
+
+                    ScreenState.Success -> MoimFinish(
+                        viewModel = viewModel,
+                        onClick = { goFrontScreen() },
+                        navController = navController)
 
                     else -> {
                         binding.progressBar.visibility = View.GONE
-                        MoimConfirm(viewModel, requireActivity(),false)
+                        MoimConfirm(viewModel, requireActivity(), false)
                     }
                 }
+            }
         }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimFragment.kt
@@ -83,10 +83,7 @@ class MoimFragment :
                         ) { navController.popBackStack() }
                     }
 
-                    ScreenState.Success -> MoimFinish(
-                        viewModel = viewModel,
-                        onClick = { goFrontScreen() },
-                        navController = navController)
+                    ScreenState.Success -> MoimFinish(viewModel = viewModel, navController = navController)
 
                     else -> {
                         binding.progressBar.visibility = View.GONE

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimIntroduce.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimIntroduce.kt
@@ -69,7 +69,7 @@ fun MoimIntroduce(
             when (event) {
                 MoimViewModel.SnackbarEvent.FILE_OVER_10MB -> {
                     val result = snackbarHostState.showSnackbar(
-                        message = event.getMessage(),
+                        message = "10mb 이하의 사진을 등록해 주세요",
                         duration = SnackbarDuration.Short
                     )
                     delay(1000)

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimIntroduce.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimIntroduce.kt
@@ -97,6 +97,8 @@ fun MoimIntroduce(
             CreateMoimTitle(string= stringResource(id = R.string.moim_introduce_title))
             TmMarginVerticalSpacer(size = 28)
             MoimIntroColumn(viewModel)
+            TmMarginVerticalSpacer(size = 8)
+            MoimSystemText(text =  R.string.moim_introduce_system_text)
             TmMarginVerticalSpacer(size = 20)
             TeumDivider()
             TmMarginVerticalSpacer(size = 20)
@@ -123,8 +125,6 @@ fun MoimIntroColumn(viewModel: MoimViewModel) {
         verticalArrangement = Arrangement.Top,
     ) {
         MoimInputField(viewModel)
-        TmMarginVerticalSpacer(size = 24)
-
     }
 }
 
@@ -174,7 +174,8 @@ fun MoimInputField(viewModel: MoimViewModel) {
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/moim/MoimViewModel.kt
@@ -305,7 +305,6 @@ class MoimViewModel @Inject constructor(
                         )
                     } else { null }
                 }
-                Log.d("requestModel", requestModel.toString())
                 if (requestModel != null) {
                     repository.postGroupMoim(requestModel, imageFiles)
                         .onSuccess { meeting ->
@@ -351,6 +350,7 @@ class MoimViewModel @Inject constructor(
         _screenState.value =
             when(_screenState.value) {
                 ScreenState.Failure -> ScreenState.Create
+                ScreenState.Server -> ScreenState.Create
                 ScreenState.Success -> ScreenState.Success
                 ScreenState.Create -> ScreenState.Address
                 ScreenState.Address -> ScreenState.DateTime

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageFragment.kt
@@ -2,9 +2,14 @@ package com.teumteum.teumteum.presentation.mypage
 
 import android.os.Bundle
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentMyPageBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -25,7 +30,9 @@ class MyPageFragment :
         (activity as MainActivity).showBottomNavi()
 
         binding.composeMypage.setContent {
-            MyPageScreen(navController = navController, viewModel = viewModel, myPageViewModel = myPageViewModel)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                MyPageScreen(navController = navController, viewModel = viewModel, myPageViewModel = myPageViewModel)
+            }
         }
     }
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageFragment.kt
@@ -43,7 +43,6 @@ class MyPageFragment :
         viewModel.getUserClosedMeeting()
     }
 
-
     companion object {
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageScreen.kt
@@ -3,6 +3,7 @@ package com.teumteum.teumteum.presentation.mypage
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,7 +48,7 @@ import com.teumteum.teumteum.util.custom.view.model.FrontCard
 fun MyPageScreen(
     navController: NavController,
     viewModel: SettingViewModel,
-    myPageViewModel: MyPageViewModel
+    myPageViewModel: MyPageViewModel,
 ) {
     val userInfoState by myPageViewModel.userInfoState.collectAsState()
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/editCard/EditCardFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/editCard/EditCardFragment.kt
@@ -7,10 +7,15 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.base.util.extension.defaultToast
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentEditCardBinding
@@ -68,7 +73,9 @@ class EditCardFragment: BindingFragment<FragmentEditCardBinding>(R.layout.fragme
         initBottomSheet()
 
         binding.composeEditCard.setContent {
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
             EditCardScreen(myPageViewModel, viewModel, navController)
+            }
         }
 
     }
@@ -76,8 +83,10 @@ class EditCardFragment: BindingFragment<FragmentEditCardBinding>(R.layout.fragme
     val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             (activity as MainActivity).showBottomNavi()
+            findNavController().popBackStack()
         }
     }
+
     override fun onResume() {
         super.onResume()
         viewModel.loadUserInfo()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/pager/MeetingPagerItems.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/pager/MeetingPagerItems.kt
@@ -33,7 +33,6 @@ import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.base.util.extension.longExtra
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.Meeting
-import com.teumteum.teumteum.presentation.mypage.setting.viewModel.MeetingDummy1
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/pager/Pager1Content.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/pager/Pager1Content.kt
@@ -20,7 +20,6 @@ import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.presentation.mypage.MyPageFragmentDirections
 import com.teumteum.teumteum.presentation.mypage.recommend.fragment.RecommendDetailFragmentDirections
-import com.teumteum.teumteum.presentation.mypage.setting.viewModel.MeetingDummy1
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.SettingViewModel
 
 @Composable

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/RecommendScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/RecommendScreen.kt
@@ -125,7 +125,7 @@ fun RecommendItem(recommend: Recommend, myPageViewModel: MyPageViewModel, navCon
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            RecommendRow(recommend = recommend, list= myPageViewModel.characterList)
+            RecommendRow(recommend = recommend, list= myPageViewModel.friendCharacterList)
             recommend.jobName?.let {
                 Text(
                     text = it,
@@ -149,7 +149,7 @@ fun RecommendRow(recommend: Recommend, list: HashMap<Int, Int>) {
             painter = painterResource(id = imageResId),
             contentDescription =null,
             modifier = Modifier
-                .size(32.dp)
+                .size(30.dp)
                 .padding(vertical = 0.dp)
         )
         TmMarginHorizontalSpacer(size = 8)

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/fragment/RecommendDetailFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/fragment/RecommendDetailFragment.kt
@@ -2,9 +2,14 @@ package com.teumteum.teumteum.presentation.mypage.recommend.fragment
 
 import android.os.Bundle
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentRecommendDetailBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -35,7 +40,15 @@ class RecommendDetailFragment: BindingFragment<FragmentRecommendDetailBinding>(R
         val navController = findNavController()
 
         binding.composeRecommendDetail.setContent {
-            RecommendDetailScreen(navController, viewModel, userId, isJoinView, requireActivity())
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                RecommendDetailScreen(
+                    navController,
+                    viewModel,
+                    userId,
+                    isJoinView,
+                    requireActivity()
+                )
+            }
         }
 
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/fragment/RecommendFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/recommend/fragment/RecommendFragment.kt
@@ -4,9 +4,14 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentRecommendBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -23,20 +28,33 @@ class RecommendFragment: BindingFragment<FragmentRecommendBinding>(R.layout.frag
         super.onViewCreated(view, savedInstanceState)
 
         userId = arguments?.getInt("id") ?: null
+        Log.d("my id", userId.toString())
+
+        if(userId == 0)    myPageViewModel.loadFriends()
+        else    userId?.let { viewModel.loadFriends(it.toLong()) }
+
 
         (activity as MainActivity).hideBottomNavi()
         val navController = findNavController()
 
         binding.composeRecommend.setContent {
-            RecommendScreen(myPageViewModel,  navController, userId, viewModel)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                RecommendScreen(myPageViewModel, navController, userId, viewModel)
+            }
         }
 
     }
 
     val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            (activity as MainActivity).showBottomNavi()
+            findNavController().popBackStack()
         }
+    }
+
+    override fun onResume() {
+        if(userId == 0)    myPageViewModel.loadFriends()
+        else    userId?.let { viewModel.loadFriends(it.toLong()) }
+        super.onResume()
     }
 
     companion object {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/EditMyInfoScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/EditMyInfoScreen.kt
@@ -41,7 +41,6 @@ fun EditMyInfoScreen(viewModel: SettingViewModel, navController: NavController) 
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 20.dp)
                 .background(color = TmtmColorPalette.current.color_background)
         ) {
             TmMarginVerticalSpacer(size = 68)
@@ -49,6 +48,7 @@ fun EditMyInfoScreen(viewModel: SettingViewModel, navController: NavController) 
                 text = stringResource(id = R.string.setting_my_info_edit_title1),
                 style = TmTypo.current.Body2,
                 color= TmtmColorPalette.current.color_text_body_quaternary,
+                modifier = Modifier.padding(horizontal = 20.dp)
             )
             TmMarginVerticalSpacer(size = 8)
             EditNameField(viewModel)
@@ -58,6 +58,7 @@ fun EditMyInfoScreen(viewModel: SettingViewModel, navController: NavController) 
                 text = stringResource(id = R.string.setting_my_info_edit_title2),
                 style = TmTypo.current.Body2,
                 color= TmtmColorPalette.current.color_text_body_quaternary,
+                modifier = Modifier.padding(horizontal = 20.dp)
             )
             TmMarginVerticalSpacer(size = 8)
             EditBirthField(viewModel)
@@ -66,6 +67,7 @@ fun EditMyInfoScreen(viewModel: SettingViewModel, navController: NavController) 
                 text = stringResource(id = R.string.setting_my_info_edit_title3),
                 style = TmTypo.current.Body2,
                 color= TmtmColorPalette.current.color_text_body_quaternary,
+                modifier = Modifier.padding(horizontal = 20.dp)
             )
             TmMarginVerticalSpacer(size = 8)
             EditSignUpBox(viewModel)
@@ -82,6 +84,7 @@ fun EditSignUpBox(viewModel: SettingViewModel) {
     Box(modifier = Modifier
         .fillMaxWidth()
         .height(56.dp)
+        .padding(horizontal =20.dp)
         .background(
             color = TmtmColorPalette.current.elevation_color_elevation_level01,
             shape = RoundedCornerShape(4.dp)
@@ -107,6 +110,7 @@ fun EditNameField(viewModel: SettingViewModel) {
         value = userName,
         modifier = Modifier
             .fillMaxWidth()
+            .padding(horizontal = 20.dp)
             .wrapContentHeight(),
         placeholder = { Text(text = stringResource(id = R.string.setting_my_info_edit_placeholder1), style= TmTypo.current.Body1, color = TmtmColorPalette.current.color_text_body_quinary) },
         onValueChange = { newText ->

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/EditMyInfoScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/EditMyInfoScreen.kt
@@ -74,6 +74,8 @@ fun EditMyInfoScreen(viewModel: SettingViewModel, navController: NavController) 
     }
 }
 
+
+
 @Composable
 fun EditSignUpBox(viewModel: SettingViewModel) {
     val text by viewModel.userAuth.collectAsState()
@@ -118,7 +120,8 @@ fun EditNameField(viewModel: SettingViewModel) {
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 }
@@ -146,7 +149,8 @@ fun EditBirthField(viewModel: SettingViewModel) {
             unfocusedBorderColor = TmtmColorPalette.current.elevation_color_elevation_level01,
             unfocusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
             focusedLabelColor = TmtmColorPalette.current.color_text_body_quinary,
-            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01
+            backgroundColor = TmtmColorPalette.current.elevation_color_elevation_level01,
+            cursorColor = TmtmColorPalette.current.TMTMBlue500,
         ),
     )
 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingScreen.kt
@@ -38,6 +38,7 @@ import com.teumteum.base.component.compose.TmScaffold
 import com.teumteum.teumteum.R
 import com.teumteum.base.component.compose.theme.TmTypo
 import com.teumteum.base.component.compose.theme.TmtmColorPalette
+import com.teumteum.teumteum.BuildConfig
 import com.teumteum.teumteum.presentation.MainActivity
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.DialogEvent
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.SettingViewModel
@@ -101,6 +102,7 @@ fun SettingScreen(viewModel: SettingViewModel, navController: NavController) {
                 .fillMaxSize()
                 .background(color = TmtmColorPalette.current.elevation_color_elevation_level01)
         ) {
+            val versionName = BuildConfig.VERSION_NAME
             TmMarginVerticalSpacer(size = 60)
             SettingAccountRow(viewModel, navController)
             TmMarginVerticalSpacer(size = 8)
@@ -108,7 +110,7 @@ fun SettingScreen(viewModel: SettingViewModel, navController: NavController) {
             SettingColumn2(viewModel, navController)
             TmMarginVerticalSpacer(size = 14)
             Text(
-                text = stringResource(id = R.string.setting_version_text),
+                text = stringResource(id = R.string.setting_version_text) + " ${versionName}",
                 style = TmTypo.current.Body2,
                 color= TmtmColorPalette.current.color_text_body_quinary,
                 modifier = Modifier.padding(horizontal = 20.dp)

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingServiceScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingServiceScreen.kt
@@ -26,7 +26,7 @@ import com.teumteum.teumteum.presentation.mypage.setting.viewModel.getServiceGui
 fun SettingServiceScreen(viewModel: SettingViewModel, navController: NavController) {
     TmScaffold(
         topbarText = stringResource(id = R.string.setting_service_guide_topbar),
-        onClick = { viewModel.updateSettingStatus(SettingStatus.SETTING) }
+        onClick = { navController.popBackStack() }
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingSignOutConfirmScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingSignOutConfirmScreen.kt
@@ -37,14 +37,14 @@ import com.teumteum.teumteum.presentation.mypage.setting.viewModel.SettingViewMo
 import com.teumteum.teumteum.presentation.mypage.setting.viewModel.UserInfoUiState
 
 @Composable
-fun SettingSignOutConfirm(viewModel: SettingViewModel, myPageViewModel: MyPageViewModel) {
+fun SettingSignOutConfirm(viewModel: SettingViewModel, myPageViewModel: MyPageViewModel, navController: NavController) {
     val userInfoState by myPageViewModel.userInfoState.collectAsState()
     val name = when (userInfoState) {
         is UserInfoUiState.Success -> "${(userInfoState as UserInfoUiState.Success).data.name}님"
         else -> "로딩 중..."
     }
     TmScaffold(
-        onClick = { viewModel.updateSettingStatus(SettingStatus.SIGNOUT)}
+        onClick = { navController.popBackStack() }
     ) {
         Column(
             modifier = Modifier
@@ -91,8 +91,8 @@ fun SettingSignOutBtn2(
     val selectedReasonsCount by viewModel.signoutReason.collectAsState()
     val isCheckboxChecked by viewModel.isCheckboxChecked.collectAsState()
     val isEnabled = selectedReasonsCount.isNotEmpty() && isCheckboxChecked
-    val buttonColors = if (isEnabled) TmtmColorPalette.current.color_button_active else TmtmColorPalette.current.Gray200
-    val textColors = if(isEnabled) TmtmColorPalette.current.GreyWhite else TmtmColorPalette.current.Gray300
+    val buttonColors = if (isEnabled) TmtmColorPalette.current.color_button_active else TmtmColorPalette.current.color_button_disabled
+    val textColors = if(isEnabled) TmtmColorPalette.current.Gray900 else TmtmColorPalette.current.color_text_button_primary_disabled
     androidx.compose.material3.Button(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingSignOutScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/SettingSignOutScreen.kt
@@ -42,6 +42,7 @@ fun SettingSignOutScreen(
     navController: NavController
 ) {
     TmScaffold(
+        onClick = { navController.popBackStack() }
     ) {
         Column(
             modifier = Modifier
@@ -73,8 +74,8 @@ fun SettingSignOutBtn1(
 ) {
     val selectedReasonsCount by viewModel.signoutReason.collectAsState()
     val isEnabled = selectedReasonsCount.isNotEmpty()
-    val buttonColors = if (isEnabled) TmtmColorPalette.current.color_button_active else TmtmColorPalette.current.Gray200
-    val textColors = if(isEnabled) TmtmColorPalette.current.GreyWhite else TmtmColorPalette.current.Gray300
+    val buttonColors = if (isEnabled) TmtmColorPalette.current.color_button_active else TmtmColorPalette.current.color_button_disabled
+    val textColors = if(isEnabled) TmtmColorPalette.current.Gray900 else TmtmColorPalette.current.color_text_button_primary_disabled
         androidx.compose.material3.Button(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/EditMyInfoFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/EditMyInfoFragment.kt
@@ -2,9 +2,14 @@ package com.teumteum.teumteum.presentation.mypage.setting.fragment
 
 import android.os.Bundle
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentEditMyinfoBinding
 import com.teumteum.teumteum.presentation.mypage.setting.EditMyInfoScreen
@@ -18,7 +23,9 @@ class EditMyInfoFragment: BindingFragment<FragmentEditMyinfoBinding>(R.layout.fr
         val navController = findNavController()
 
         binding.composeEditMyinfo.setContent {
-            EditMyInfoScreen(viewModel, navController)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                EditMyInfoScreen(viewModel, navController)
+            }
         }
     }
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/ServiceFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/ServiceFragment.kt
@@ -3,9 +3,14 @@ package com.teumteum.teumteum.presentation.mypage.recommend.fragment
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentServiceBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -17,32 +22,23 @@ class ServiceFragment: BindingFragment<FragmentServiceBinding>(R.layout.fragment
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-//        lifecycleScope.launchWhenStarted {
-//            viewModel.settingStatus.collect { status ->
-//                handleSettingStatus(status)
-//            }
-//        }
         val navController = findNavController()
 
         binding.composeService.setContent {
-            SettingServiceScreen(viewModel, navController)
+            CompositionLocalProvider(TmtmColorPalette provides if (isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light) {
+                SettingServiceScreen(viewModel, navController)
+            }
+
         }
     }
 
     val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             (activity as MainActivity).showBottomNavi()
+            findNavController().popBackStack()
         }
     }
 
-//    private fun handleSettingStatus(status: SettingStatus) {
-//        when (status) {
-//            SettingStatus.SETTING -> {
-//                findNavController().popBackStack()
-//            }
-//            else -> {}
-//        }
-//    }
 
     companion object {
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SettingFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SettingFragment.kt
@@ -4,10 +4,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.base.util.extension.defaultToast
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentSettingBinding
@@ -32,7 +37,9 @@ class SettingFragment: BindingFragment<FragmentSettingBinding>(R.layout.fragment
         (activity as MainActivity).hideBottomNavi()
 
         binding.composeSetting.setContent {
-            SettingScreen(viewModel, navController)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                SettingScreen(viewModel, navController)
+            }
         }
 
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SignOutConfirmFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SignOutConfirmFragment.kt
@@ -4,10 +4,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentSignoutBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -30,9 +35,12 @@ class SignOutConfirmFragment: BindingFragment<FragmentSignoutBinding>(R.layout.f
         }
 
         (activity as MainActivity).hideBottomNavi()
+        val navController = findNavController()
 
         binding.composeSignout.setContent {
-            SettingSignOutConfirm(viewModel = viewModel, myPageViewModel =  myPageViewModel)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                SettingSignOutConfirm(viewModel = viewModel, myPageViewModel = myPageViewModel, navController = navController)
+            }
         }
 
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SignOutFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/fragment/SignOutFragment.kt
@@ -3,10 +3,15 @@ package com.teumteum.teumteum.presentation.mypage.setting.fragment
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.teumteum.base.BindingFragment
+import com.teumteum.base.component.compose.theme.ColorPalette_Dark
+import com.teumteum.base.component.compose.theme.ColorPalette_Light
+import com.teumteum.base.component.compose.theme.TmtmColorPalette
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.FragmentSignoutBinding
 import com.teumteum.teumteum.presentation.MainActivity
@@ -23,7 +28,9 @@ class SignOutFragment: BindingFragment<FragmentSignoutBinding>(R.layout.fragment
         (activity as MainActivity).hideBottomNavi()
 
         binding.composeSignout.setContent {
-            SettingSignOutScreen(viewModel, navController)
+            CompositionLocalProvider(TmtmColorPalette provides if(isSystemInDarkTheme()) ColorPalette_Dark else ColorPalette_Light ) {
+                SettingSignOutScreen(viewModel, navController)
+            }
         }
 
     }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/MyPageViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/MyPageViewModel.kt
@@ -83,11 +83,25 @@ class MyPageViewModel @Inject constructor(
         11 to R.drawable.ic_card_front_panda
     )
 
+    val friendCharacterList: HashMap<Int, Int> = hashMapOf(
+        0 to R.drawable.ic_ghost,
+        1 to R.drawable.ic_star,
+        2 to R.drawable.ic_bear,
+        3 to R.drawable.ic_raccoon,
+        4 to R.drawable.ic_cat,
+        5 to R.drawable.ic_rabbit,
+        6 to R.drawable.ic_fox,
+        7 to R.drawable.ic_water,
+        8 to R.drawable.ic_penguin,
+        9 to R.drawable.ic_dog,
+        10 to R.drawable.ic_mouse,
+        11 to R.drawable.ic_panda
+    )
 
     fun userInfoToFrontCard(userInfo: UserInfo, characterList: HashMap<Int, Int>): FrontCard {
         return FrontCard(
             name = userInfo.name,
-            company = userInfo.job.name ?: "@직장,학교명",
+            company = "@${userInfo.job.name}" ?: "@직장,학교명",
             job = userInfo.job.detailClass,
             level = "lv.${userInfo.mannerTemperature}층",
             area = "${userInfo.activityArea}에 사는",

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/MyPageViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/MyPageViewModel.kt
@@ -34,6 +34,7 @@ class MyPageViewModel @Inject constructor(
 
     init {
         loadUserInfo()
+        loadFriends()
     }
 
     fun loadFriends() {

--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/SettingMeetingUiModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/setting/viewModel/SettingMeetingUiModel.kt
@@ -42,14 +42,6 @@ data class SettingUiItem(
     val onClick: () -> Unit = {}
 )
 
-val MeetingDummy = listOf(
-    Meeting("UX 북스터디", "1월 9일 오후 7:00"),
-    Meeting("프로덕트 디자이너 포폴 리뷰 세션", "1월 8일 오후 6:00"),
-    Meeting("커피 마시며 고민 말하기", "1월 7일 오후 9:00"),
-)
-
-val MeetingDummy1 = Meeting("UX 북스터디", "1월 9일 오후 7:00")
-
 val UserGradeDummy = listOf(
     UserGrade("Excellent", "최고에요!", 3, R.drawable.ic_grade_exel),
     UserGrade("Good", "좋아요!", 2, R.drawable.ic_grade_good),

--- a/app/src/main/java/com/teumteum/teumteum/util/callback/CustomBackPressedCallback.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/callback/CustomBackPressedCallback.kt
@@ -5,7 +5,7 @@ import androidx.activity.OnBackPressedCallback
 import com.teumteum.base.BindingActivity
 import com.teumteum.base.util.extension.defaultToast
 
-class CustomBackPressedCallback(private val activity: Activity, private val message: String)
+open class CustomBackPressedCallback(private val activity: Activity, private val message: String)
     : OnBackPressedCallback(true) {
 
     private var backKeyPressedTime = 0L

--- a/app/src/main/res/layout/fragment_moim.xml
+++ b/app/src/main/res/layout/fragment_moim.xml
@@ -26,7 +26,7 @@
             android:layout_width="0dp"
             android:layout_height="4dp"
             android:layout_marginTop="56dp"
-            android:max="700"
+            android:max="600"
             android:progress="100"
             android:progressDrawable="@drawable/progress_bar_color"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,11 +111,12 @@
 
     <string name="moim_topic_title">어떤 주제로 모임을 만들까요?</string>
     <string name="moim_next_btn">다음</string>
+    <string name="moim_confirm_btn">모임 열기</string>
 
     <string name="moim_name_title">모임 이름을 작성해 주세요</string>
 
     <string name="moim_introduce_title">모임을 소개해 주세요</string>
-    <string name="moim_introduce_system_text">추천 수가 20개가 넘는 인기글의 경우 스팸 광고를 차단하기 위해 게시글 수정이 불가합니다.</string>
+    <string name="moim_introduce_system_text">모임 소개 글은 10자를 넘어야 합니다.</string>
     <string name="moim_introduce_title1_photo">사진 등록</string>
     <string name="moim_introduce_title2_photo">최대 5장</string>
     <string name="moim_introduce_system_photo">1장 이상의 사진을 필수로 등록해주세요.</string>
@@ -244,7 +245,6 @@
     <string name="moim_confirm_title3">인원</string>
     <string name="moim_confirm_title4">장소</string>
     <string name="moim_confirm_title5">모임 소개</string>
-    <string name="moim_confirm_btn">모임 열기</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,10 @@
     <string name="setting_edit_card_btn">수정 완료</string>
     <string name="setting_edit_chip_plus">추가하기</string>
 
+    <string name="moim_alert_message_failure">모임 신청에 오류가 발생했습니다</string>
+    <string name="moim_alert_message_server">서버 통신에 실패했습니다</string>
+    <string name="moim_alert_message_success">모임 취소를 성공했습니다</string>
+
     <string name="setting_edit_card_topbar">소개서 수정하기</string>
     <string name="setting_edit_card_placeholder1">실명을 입력해주세요</string>
     <string name="setting_edit_card_placeholder2">생년월일을 입력해주세요. (20000101)</string>

--- a/core/base/src/main/java/com/teumteum/base/component/compose/TmScaffold.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/compose/TmScaffold.kt
@@ -30,6 +30,8 @@ fun TmScaffold(
     isSetting: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
+    val TmtmColorPalette = TmtmColorPalette
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
@@ -97,7 +97,7 @@ val ColorPalette_Dark = ColorPalette(
     color_text_caption_quaternary_default = Color(color = 0xFF444444), // gray300
 
     color_text_button_primary_default = Color(color = 0xFFFFFFFF),
-    color_text_button_primary_default02 = Color(color = 0xFF444444),
+    color_text_button_primary_default02 = Color(color = 0xFFF5F5F5),
     color_text_button_primary_press = Color(color = 0xFF96D7FF), // tmtm blue 200
     color_text_button_primary_disabled = Color(color = 0xFF444444),
     color_text_button_secondary_default = Color(color = 0xFF36B2FF),

--- a/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
@@ -128,7 +128,7 @@ val ColorPalette_Dark = ColorPalette(
 
     color_button_active = Color(color = 0xFF36B2FF),
     color_button_disabled = Color(color = 0xFF292929),
-    color_button_alternative = Color(color = 0xFFE9E9E9),
+    color_button_alternative = Color(color = 0xFF575757),
 
     GreyWhite = Color(color = 0xFF1111111),
     ColorDivider = Color(color = 0xFF212121),

--- a/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/compose/theme/Color.kt
@@ -1,5 +1,10 @@
 package com.teumteum.base.component.compose.theme
 
+import android.provider.CalendarContract
+import androidx.appcompat.app.AppCompatDelegate.NightMode
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.Colors
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
@@ -10,141 +15,199 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+@Immutable
+data class ColorPalette(
+    val color_text_headline_primary: Color = Color.Unspecified,
+    val color_text_headline_secondary: Color = Color.Unspecified,
+    val color_text_headline_teritary: Color = Color.Unspecified,
 
-data class ColorPalette_Dark(
-    //headline
-    val color_text_headline_primary: Color = Color(0xFFF5F5F5), //gray900
-    val color_text_headline_secondary: Color = Color(0xFFE9E9E9), //gray800
-    val color_text_headline_teritary: Color = Color(0xFF828282), //gray550
+    val color_text_body_primary: Color = Color.Unspecified,
+    val color_text_body_secondary: Color = Color.Unspecified,
+    val color_text_body_teritary: Color = Color.Unspecified,
+    val color_text_body_quaternary: Color = Color.Unspecified,
+    val color_text_body_quinary: Color = Color.Unspecified,
 
-    //body
-    val color_text_body_primary: Color = Color(0xFFF5F5F5), // gray700
-    val color_text_body_secondary: Color = Color(0xFFC9C9C9), //gray600
-    val color_text_body_teritary: Color = Color(0xFFA6A6A6), //gray600
-    val color_text_body_quaternary : Color = Color(0xFF828282), //gray550
-    val color_text_body_quinary: Color = Color(0xFF444444), //gray300
+    val color_text_caption_primary_default: Color = Color.Unspecified,
+    val color_text_caption_primary_error: Color = Color.Unspecified,
+    val color_text_caption_secondary_default: Color = Color.Unspecified,
+    val color_text_caption_teritary_default: Color = Color.Unspecified,
+    val color_text_caption_quaternary_default: Color = Color.Unspecified,
 
-    //caption
-    val color_text_caption_primary_default: Color =Color(0xFFF5F5F5), //gray800
-    val color_text_caption_primary_error: Color = Color(0xFFC4E6D), //error300
-    val color_text_caption_secondary_default: Color = Color(0xFFE9E9E9), //gray600
-    val color_text_caption_teritary_default: Color = Color(0xFF828282), //gray400
-    val color_text_caption_quaternary_default: Color = Color(0xFF444444), //gray300
+    val color_text_button_primary_default: Color = Color.Unspecified,
+    val color_text_button_primary_default02: Color = Color.Unspecified,
+    val color_text_button_primary_press: Color = Color.Unspecified,
+    val color_text_button_primary_disabled: Color = Color.Unspecified,
+    val color_text_button_secondary_default: Color = Color.Unspecified,
+    val color_text_button_alternative: Color = Color.Unspecified,
 
-    //button
-    val color_text_button_primary_default: Color = Color(0xFFFFFFFF),
-    val color_text_button_primary_default02: Color = Color(0xFF444444),
-    val color_text_button_primary_press: Color = Color(0xFF96D7FF), //tmtm blue 200
-    val color_text_button_primary_disabled: Color = Color(0xFF444444),
-    val color_text_button_secondary_default: Color = Color(0xFF36B2FF),
-    val color_text_button_alternative: Color = Color(0xFFFFFFFF),
+    val color_outline_level04_active: Color = Color.Unspecified,
+    val color_outline_level03: Color = Color.Unspecified,
 
-    //outline
-    val color_outline_level04_active: Color = Color(0xFFF5F5F5),
-    val color_outline_level03: Color = Color(0xFF333333),
+    val color_icon_level02_disabled: Color = Color.Unspecified,
+    val color_icon_level02_active: Color = Color.Unspecified,
+    val color_icon_level01: Color = Color.Unspecified,
 
-    //icon
-    val color_icon_level02_disabled: Color = Color(0xFF333333),
-    val color_icon_level02_active: Color = Color(0xFF36B2FF),
-    val color_icon_level01: Color = Color(0xFFF5F5F5),
+    val Gray950: Color = Color.Unspecified,
+    val Gray900: Color = Color.Unspecified,
+    val Gray800: Color = Color.Unspecified,
+    val Gray700: Color = Color.Unspecified,
+    val Gray550: Color = Color.Unspecified,
+    val Gray500: Color = Color.Unspecified,
+    val Gray400: Color = Color.Unspecified,
+    val Gray300: Color = Color.Unspecified,
+    val Gray200: Color = Color.Unspecified,
+    val Gray50: Color = Color.Unspecified,
 
+    val Error300: Color = Color.Unspecified,
+    val TMTMBlue200: Color = Color.Unspecified,
+    val TMTMBlue400: Color = Color.Unspecified,
+    val TMTMBlue500: Color = Color.Unspecified,
 
-    val Gray950: Color = Color(0xFFFFFFFF),//light gray 950
-    val Gray900: Color = Color(0xFFFFFFFF), //light gray 900
-    val Gray800: Color = Color(0xFFF5F5F5), //light gray 50
-    val Gray700: Color = Color(0xFFF5F5F5), //light gray 50
-    val Gray550: Color = Color(0xFFA6A6A6), //light gray 400
-    val Gray500: Color = Color(0xFF828282),//light gray 500
-    val Gray400: Color = Color(0xFF828282), //light gray 500
-    val Gray300: Color = Color(0xFFC9C9C9), //light gray 700
-    val Gray200: Color = Color(0xFF333333), //light grey800
-    val Gray50: Color = Color(0xFF1111111), //light gray50
+    val color_button_active: Color = Color.Unspecified,
+    val color_button_disabled: Color = Color.Unspecified,
+    val color_button_alternative: Color = Color.Unspecified,
 
-    val Error300: Color = Color(0xFFFC4E6D),
-    val TMTMBlue200: Color = Color(0xFF96D7FF),
-    val TMTMBlue400: Color = Color(0xFF36B2FF),
-    val TMTMBlue500: Color = Color(0xFF0FA4FF),
+    val GreyWhite: Color = Color.Unspecified,
+    val ColorDivider: Color = Color.Unspecified,
 
-    val color_button_active: Color = Color(0xFF36B2FF),
-    val color_button_disabled: Color = Color(0xFF292929),
-    val color_button_alternative : Color = Color(0xFFE9E9E9),
+    val elevation_color_elevation_level01: Color = Color.Unspecified,
+    val elevation_color_elevation_level02: Color = Color.Unspecified,
 
-    val GreyWhite: Color = Color(0xFF1111111),
-    val ColorDivider: Color = Color(0xFF212121),
-
-    val elevation_color_elevation_level01: Color = Color(0xFF212121),
-    val elevation_color_elevation_level02: Color = Color(0xFFE9E9E9),
-
-    val color_background: Color = Color(0xFF111111),
-
-    val color_outline_level04_disabled: Color = Color(0xFF333333),
-    val color_outline_level01_error: Color = Color(0xFFFC4E6D),
+    val color_background: Color = Color.Unspecified,
+    val color_outline_level04_disabled: Color = Color.Unspecified,
+    val color_outline_level01_error: Color = Color.Unspecified,
 )
 
-data class ColorPalette_Light(
-    //headline
-    val color_text_headline_primary: Color = Color(0xFF212121), //gray900
-    val color_text_headline_secondary: Color = Color(0xFF333333), //gray800
-    val color_text_headline_teritary: Color = Color(0xFF828282), //gray550
 
-    //body
-    val color_text_body_primary: Color = Color(0xFF444444), // gray700
-    val color_text_body_secondary: Color = Color(0xFF575757), //gray600
-    val color_text_body_teritary: Color = Color(0xFF6E6E6E), //gray600
-    val color_text_body_quaternary : Color = Color(0xFF828282), //gray550
-    val color_text_body_quinary: Color = Color(0xFFC9C9C9), //gray300
+val ColorPalette_Dark = ColorPalette(
+    color_text_headline_primary = Color(color = 0xFFF5F5F5), // gray900
+    color_text_headline_secondary = Color(color = 0xFFE9E9E9), // gray800
+    color_text_headline_teritary = Color(color = 0xFF828282), // gray550
 
-    //caption
-    val color_text_caption_primary_default: Color =Color(0xFF333333), //gray800
-    val color_text_caption_primary_error: Color = Color(0xFFFC4E6D), //error300
-    val color_text_caption_secondary_default: Color = Color(0xFF575757), //gray600
-    val color_text_caption_teritary_default: Color = Color(0xFFA6A6A6), //gray400
-    val color_text_caption_quaternary_default: Color = Color(0xFFC9C9C9), //gray300
+    color_text_body_primary = Color(color = 0xFFF5F5F5), // gray700
+    color_text_body_secondary = Color(color = 0xFFC9C9C9), // gray600
+    color_text_body_teritary = Color(color = 0xFFA6A6A6), // gray600
+    color_text_body_quaternary = Color(color = 0xFF828282), // gray550
+    color_text_body_quinary = Color(color = 0xFF444444), // gray300
 
-    //button
-    val color_text_button_primary_default: Color = Color(0xFFFFFFFF),
-    val color_text_button_primary_default02: Color = Color(0xFF444444),
-    val color_text_button_primary_press: Color = Color(0xFF96D1FF), //tmtm blue 200
-    val color_text_button_primary_disabled: Color = Color(0xFFC9C9C9),
-    val color_text_button_secondary_default: Color = Color(0xFF44AEFF),
-    val color_text_button_alternative: Color = Color(0xFF212121),
+    color_text_caption_primary_default = Color(color = 0xFFF5F5F5), // gray800
+    color_text_caption_primary_error = Color(color = 0xFFC4E6D), // error300
+    color_text_caption_secondary_default = Color(color = 0xFFE9E9E9), // gray600
+    color_text_caption_teritary_default = Color(color = 0xFF828282), // gray400
+    color_text_caption_quaternary_default = Color(color = 0xFF444444), // gray300
 
-    //outline
-    val color_outline_level03: Color = Color(0xFFE9E9E9),
-    val color_outline_level04_active: Color = Color(0xFF212121),
+    color_text_button_primary_default = Color(color = 0xFFFFFFFF),
+    color_text_button_primary_default02 = Color(color = 0xFF444444),
+    color_text_button_primary_press = Color(color = 0xFF96D7FF), // tmtm blue 200
+    color_text_button_primary_disabled = Color(color = 0xFF444444),
+    color_text_button_secondary_default = Color(color = 0xFF36B2FF),
+    color_text_button_alternative = Color(color = 0xFFFFFFFF),
 
-    //icon
-    val color_icon_level02_disabled: Color = Color(0xFFDFDFDF),
-    val color_icon_level02_active: Color = Color(0xFF44AEFF),
-    val color_icon_level01: Color = Color(0xFF212121),
+    color_outline_level04_active = Color(color = 0xFFF5F5F5),
+    color_outline_level03 = Color(color = 0xFF333333),
 
-    val Gray950: Color = Color(0xFF191919),
-    val Gray900: Color = Color(0xFF212121),
-    val Gray700: Color = Color(0xFF444444),
-    val Gray550: Color = Color(0xFF6E6E6E),
-    val Gray500: Color = Color(0xFF828282),
-    val Gray400: Color = Color(0xFFA6A6A6),
-    val Gray300: Color = Color(0xFFC9C9C9),
-    val Gray200: Color = Color(0xFFE9E9E9),
-    val Gray50: Color = Color(0xFFF5F5F5),
-    val Error300: Color = Color(0xFFFC4E6D),
+    color_icon_level02_disabled = Color(color = 0xFF333333),
+    color_icon_level02_active = Color(color = 0xFF36B2FF),
+    color_icon_level01 = Color(color = 0xFFF5F5F5),
 
-    //Tmtm Blue
-    val TMTMBlue200: Color = Color(0xFF96D7FF),
-    val TMTMBlue400: Color = Color(0xFF444AEFF),
-    val TMTMBlue500: Color = Color(0xFF1A9CFF),
+    Gray950 = Color(color = 0xFFFFFFFF), // light gray 950
+    Gray900 = Color(color = 0xFFFFFFFF), // light gray 900
+    Gray800 = Color(color = 0xFFF5F5F5), // light gray 50
+    Gray700 = Color(color = 0xFFF5F5F5), // light gray 50
+    Gray550 = Color(color = 0xFFA6A6A6), // light gray 400
+    Gray500 = Color(color = 0xFF828282), // light gray 500
+    Gray400 = Color(color = 0xFF828282), // light gray 500
+    Gray300 = Color(color = 0xFFC9C9C9), // light gray 700
+    Gray200 = Color(color = 0xFF333333), // light gray 800
+    Gray50 = Color(color = 0xFF1111111), // light gray 50
 
-    val color_button_active: Color = Color(0xFF44AEFF),
-    val color_button_disabled: Color = Color(0xFFE9E9E9),
-    val GreyWhite: Color = Color(0xFFFFFFFF),
-    val ColorDivider: Color = Color(0xFFF0F0F0),
-    val elevation_color_elevation_level01: Color = Color(0xFFF5F5F5),
-    val elevation_color_elevation_level02: Color = Color(0xFFE9E9E9),
-    val color_background: Color = Color(0xFFFFFFFF),
-    val color_outline_level04_disabled: Color = Color(0xFFE9E9E9),
-    val color_button_alternative : Color = Color(0xFFE9E9E9),
+    Error300 = Color(color = 0xFFFC4E6D),
+    TMTMBlue200 = Color(color = 0xFF96D7FF),
+    TMTMBlue400 = Color(color = 0xFF36B2FF),
+    TMTMBlue500 = Color(color = 0xFF0FA4FF),
 
-    val color_outline_level01_error: Color = Color(0xFFFC4E6D),
+    color_button_active = Color(color = 0xFF36B2FF),
+    color_button_disabled = Color(color = 0xFF292929),
+    color_button_alternative = Color(color = 0xFFE9E9E9),
+
+    GreyWhite = Color(color = 0xFF1111111),
+    ColorDivider = Color(color = 0xFF212121),
+
+    elevation_color_elevation_level01 = Color(color = 0xFF212121),
+    elevation_color_elevation_level02 = Color(color = 0xFFE9E9E9),
+
+    color_background = Color(color = 0xFF111111),
+
+    color_outline_level04_disabled = Color(color = 0xFF333333),
+    color_outline_level01_error =  Color(color =0xFFFC4E6D)
 )
 
-val TmtmColorPalette = staticCompositionLocalOf { ColorPalette_Dark() }
+
+val ColorPalette_Light = ColorPalette(
+    //headline
+    color_text_headline_primary = Color(0xFF212121), //gray900
+    color_text_headline_secondary = Color(0xFF333333), //gray800
+     color_text_headline_teritary = Color(0xFF828282), //gray550
+
+    //body
+    color_text_body_primary = Color(color = 0xFF444444), // gray700
+    color_text_body_secondary = Color(color = 0xFF575757), // gray600
+    color_text_body_teritary = Color(color = 0xFF6E6E6E), // gray600
+    color_text_body_quaternary = Color(color = 0xFF828282), // gray550
+    color_text_body_quinary = Color(color = 0xFFC9C9C9), // gray300
+
+    //caption
+    color_text_caption_primary_default = Color(color = 0xFF333333), // gray800
+    color_text_caption_primary_error = Color(color = 0xFFFC4E6D), // error300
+    color_text_caption_secondary_default = Color(color = 0xFF575757), // gray600
+    color_text_caption_teritary_default = Color(color = 0xFFA6A6A6), // gray400
+    color_text_caption_quaternary_default = Color(color = 0xFFC9C9C9), // gray300
+
+    //button
+    color_text_button_primary_default = Color(color = 0xFFFFFFFF),
+    color_text_button_primary_default02 = Color(color = 0xFF444444),
+    color_text_button_primary_press = Color(color = 0xFF96D1FF), // tmtm blue 200
+    color_text_button_primary_disabled = Color(color = 0xFFC9C9C9),
+    color_text_button_secondary_default = Color(color = 0xFF44AEFF),
+    color_text_button_alternative = Color(color = 0xFF212121),
+
+    //outline
+    color_outline_level03 = Color(color = 0xFFE9E9E9),
+    color_outline_level04_active = Color(color = 0xFF212121),
+
+    //icon
+    color_icon_level02_disabled = Color(color = 0xFFDFDFDF),
+    color_icon_level02_active = Color(color = 0xFF44AEFF),
+    color_icon_level01 = Color(color = 0xFF212121),
+
+
+    Gray950 = Color(color = 0xFF191919), // light gray 950
+    Gray900 = Color(color = 0xFF212121), // light gray 900
+    Gray700 = Color(color = 0xFF444444), // light gray 700
+    Gray550 = Color(color = 0xFF6E6E6E), // light gray 550
+    Gray500 = Color(color = 0xFF828282), // light gray 500
+    Gray400 = Color(color = 0xFFA6A6A6), // light gray 400
+    Gray300 = Color(color = 0xFFC9C9C9), // light gray 300
+    Gray200 = Color(color = 0xFFE9E9E9), // light gray 200
+    Gray50 = Color(color = 0xFFF5F5F5), // light gray 50
+    Error300 = Color(color = 0xFFFC4E6D), // error 300
+
+    TMTMBlue200 = Color(color = 0xFF96D7FF), // tmtm blue 200
+    TMTMBlue400 = Color(color = 0xFF444AEFF), // tmtm blue 400
+    TMTMBlue500 = Color(color = 0xFF1A9CFF), // tmtm blue 500
+
+    color_button_active = Color(color = 0xFF44AEFF), // button active
+    color_button_disabled = Color(color = 0xFFE9E9E9), // button disabled
+    color_button_alternative = Color(color = 0xFFE9E9E9), // button alternative
+
+    GreyWhite = Color(color = 0xFFFFFFFF), // grey white
+    ColorDivider = Color(color = 0xFFF0F0F0), // color divider
+    elevation_color_elevation_level01 = Color(color = 0xFFF5F5F5), // elevation level 1
+    elevation_color_elevation_level02 = Color(color = 0xFFE9E9E9), // elevation level 2
+    color_background = Color(color = 0xFFFFFFFF), // background color
+    color_outline_level04_disabled = Color(color = 0xFFE9E9E9), // outline level 4 disabled
+    color_outline_level01_error = Color(color = 0xFFFC4E6D), // outline level 1 error
+    Gray800 = Color(color = 0xFF333333) // light gray 800
+)
+
+val TmtmColorPalette = staticCompositionLocalOf { ColorPalette() }

--- a/core/base/src/main/java/com/teumteum/base/component/compose/theme/Theme.kt
+++ b/core/base/src/main/java/com/teumteum/base/component/compose/theme/Theme.kt
@@ -53,20 +53,21 @@ fun TeumTeumTheme(
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+        darkTheme -> ColorPalette_Dark
+        else -> ColorPalette_Light
     }
+
+    val CustomColorPalette = if(darkTheme) ColorPalette_Dark else ColorPalette_Light
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
 
     CompositionLocalProvider(
-        TmtmColorPalette provides ColorPalette_Dark(),
+        TmtmColorPalette provides CustomColorPalette,
         TmTypo provides Type(),
         TmDimen provides Dimen()
     ) {

--- a/core/data/src/main/java/com/teumteum/data/datasource/remote/RemoteUserDataSource.kt
+++ b/core/data/src/main/java/com/teumteum/data/datasource/remote/RemoteUserDataSource.kt
@@ -3,6 +3,7 @@ package com.teumteum.data.datasource.remote
 import com.teumteum.data.model.request.RequestUserInfoWithOAuthId
 import com.teumteum.data.service.UserService
 import com.teumteum.domain.entity.Friend
+import com.teumteum.domain.entity.FriendRecommend
 import com.teumteum.domain.entity.Friends
 import com.teumteum.domain.entity.SignUpResult
 import com.teumteum.domain.entity.UserInfo
@@ -27,7 +28,7 @@ class RemoteUserDataSource @Inject constructor(
         return service.postUserInfo(userInfo)
     }
 
-    suspend fun getUserFriend(userId: Long): Friends {
+    suspend fun getUserFriend(userId: Long): FriendRecommend {
         return service.getUserFriends(userId)
     }
 

--- a/core/data/src/main/java/com/teumteum/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teumteum/data/repository/UserRepositoryImpl.kt
@@ -6,6 +6,8 @@ import com.teumteum.domain.TeumTeumDataStore
 import com.teumteum.data.datasource.remote.RemoteUserDataSource
 import com.teumteum.data.model.request.RequestUserInfo
 import com.teumteum.domain.entity.Friend
+import com.teumteum.domain.entity.FriendMyPage
+import com.teumteum.domain.entity.FriendRecommend
 import com.teumteum.domain.entity.Friends
 import com.teumteum.domain.entity.SignUpResult
 import com.teumteum.domain.entity.UserInfo
@@ -62,7 +64,7 @@ class UserRepositoryImpl @Inject constructor(
         dataStore.userInfo = ""
     }
 
-    override suspend fun getUserFriends(userId: Long): Result<Friends> {
+    override suspend fun getUserFriends(userId: Long): Result<FriendRecommend> {
             return runCatching {
                 dataSource.getUserFriend(userId)
             }

--- a/core/data/src/main/java/com/teumteum/data/service/UserService.kt
+++ b/core/data/src/main/java/com/teumteum/data/service/UserService.kt
@@ -2,6 +2,7 @@ package com.teumteum.data.service
 
 import com.teumteum.data.model.request.RequestUserInfoWithOAuthId
 import com.teumteum.domain.entity.Friend
+import com.teumteum.domain.entity.FriendRecommend
 import com.teumteum.domain.entity.Friends
 import com.teumteum.domain.entity.SignUpResult
 import com.teumteum.domain.entity.UserInfo
@@ -27,7 +28,7 @@ interface UserService {
     @GET("users/{userId}/friends")
     suspend fun getUserFriends(
         @Path("userId") userId: Long
-    ): Friends
+    ): FriendRecommend
 
     @GET("users/{userId}")
     suspend fun getUser(

--- a/core/domain/src/main/java/com/teumteum/domain/entity/Friend.kt
+++ b/core/domain/src/main/java/com/teumteum/domain/entity/Friend.kt
@@ -26,5 +26,10 @@ data class FriendMyPage(
 @Serializable
 data class Friends(
     val friends: List<FriendMyPage>,
-    val introductions: List<Friend>
+    val introductions: List<Friend>?
 ) : java.io.Serializable
+
+@Serializable
+data class FriendRecommend(
+    val friends: List<FriendMyPage>
+)

--- a/core/domain/src/main/java/com/teumteum/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/teumteum/domain/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.teumteum.domain.repository
 
 import com.teumteum.domain.entity.Friend
+import com.teumteum.domain.entity.FriendRecommend
 import com.teumteum.domain.entity.Friends
 import com.teumteum.domain.entity.SignUpResult
 import com.teumteum.domain.entity.UserInfo
@@ -20,7 +21,7 @@ interface UserRepository {
     fun deleteUserInfo()
     suspend fun getUser(userId: Long): Result<Friend>
     suspend fun getUsers(id: String): Result<Users>
-    suspend fun getUserFriends(userId: Long):Result<Friends>
+    suspend fun getUserFriends(userId: Long):Result<FriendRecommend>
     suspend fun updateUserInfo(user: UserInfo): Result<Unit>
     suspend fun getFriendInfo(userId: Long): UserInfo?
     suspend fun postFriend(userId: Long): Result<Unit>


### PR DESCRIPTION
## 📌 개요
- open #104

## ✨ 작업 내용
- [x] **Setting**: 라이트모드 / 다크 모드 자동 변경 설정
- [x] **Setting**: homeFragment에서만 뒤로가기 두번시 종료 
- [x] **Teum1-20**: moim 화면 버튼 빼고 스크롤 하기 수정 
- [x] **Teum1-7** : 모임 생성 전체적인 플로우 오류 수정 + 화면 수정 
- [x] **Teum1-30** : 모임 상세 페이지 사진 크롭 수정 

> 다른 프래그먼트에서는 navGraph 그대로 적용됩니다 

## ✍🏻 메모 
back stack 수정했습니다 

@unam98 navGraph 손본 김에 말씀하셨던 문제를 해결하려고 했었는데 어제 제가 말한 방법으로 해결이 안됩니다 제 생각에는 navGraph에서 아예 teumteumFragment를 빼고 main에서 메뉴 클릭했을때

>  IF 온보딩 안했음 -> onboarding Activity / ELSE -> 그 뒤에 있는 화면 

이렇게 이어줘야 할 것 같아요

