### PR TITLE
[FIX/#126] 취업준비생 유저 직업명 수정

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/SignUpViewModel.kt
@@ -354,7 +354,7 @@ class SignUpViewModel @Inject constructor(
                     readyJobDetailClass.value
                 )
                 STATUS_TRAINEE -> JobEntity(
-                    null,
+                    TRAINEE_NAME,
                     false,
                     readyJobClass.value,
                     readyJobDetailClass.value
@@ -387,6 +387,7 @@ class SignUpViewModel @Inject constructor(
 
     companion object {
         private const val REGEX_ID_PATTERN = "^([A-Za-z0-9_.]*)\$"
+        private const val TRAINEE_NAME = "준비중"
     }
 }
 

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/complete/CardCompleteFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/complete/CardCompleteFragment.kt
@@ -46,7 +46,7 @@ class CardCompleteFragment
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
                     STATUS_STUDENT -> FrontCard(userName.value, "@${schoolName.value}", readyJobDetailClass.value,
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
-                    STATUS_TRAINEE -> FrontCard(userName.value, "@준비 중", readyJobDetailClass.value,
+                    STATUS_TRAINEE -> FrontCard(userName.value, "@${getText(R.string.signup_tv_card_trainee_job)}", readyJobDetailClass.value,
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
                     else -> FrontCard()
                 }

--- a/app/src/main/java/com/teumteum/teumteum/presentation/signup/fix/CardFixFragment.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/signup/fix/CardFixFragment.kt
@@ -56,7 +56,7 @@ class CardFixFragment
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
                     STATUS_STUDENT -> FrontCard(userName.value, "@${schoolName.value}", readyJobDetailClass.value,
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
-                    STATUS_TRAINEE -> FrontCard(userName.value, "@준비 중", readyJobDetailClass.value,
+                    STATUS_TRAINEE -> FrontCard(userName.value, "@${getText(R.string.signup_tv_card_trainee_job)}", readyJobDetailClass.value,
                         "lv.1층", "${preferredArea.value}에 사는", mbtiText.value.toUpperCase(Locale.ROOT), it)
                     else -> FrontCard()
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="signup_tv_finish_title">가입을 완료했어요</string>
     <string name="signup_tv_finish_subtitle">또래와 함께하는 맞춤형 모임을 추천해드려요</string>
     <string name="signup_tv_go_home">홈으로 가기</string>
+    <string name="signup_tv_card_trainee_job">준비중</string>
 
     <string name="alert_back_pressed_finish">\'뒤로\' 버튼을 두 번 누르면 종료됩니다</string>
     <string name="alert_back_pressed_signup">\'뒤로\' 버튼을 두 번 누르면 회원가입을 종료합니다</string>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- close #126

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 취업준비생 유저 직업명 수정
-> 서버에 회원가입 쏠 때 준비중으로 쏨
-> 신규 회원은 민서쓰 자기소개 카드에서도 준비중으로 잘 뜨는거 확인 완
-> 기존 회원은 서버가 디비 고쳐줄거임~
 
## 📸 스크린샷/동영상