### PR TITLE
[feat/#138] 카드 뒷면 관심사 삭제/추가 디테일 수정

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/mypage/MyPageScreen.kt
@@ -206,15 +206,6 @@ fun BackCardView(backCard: BackCard) {
         factory = { context ->
             BackCardView(context).apply {
                 getInstance(backCard)
-                submitInterestList( //todo - 더미
-                    listOf(
-                        Interest("모여서 각자 일하기"),
-                        Interest("사이드 프로젝트"),
-                        Interest("네트워킹")
-                    )
-                )
-                setIsModifyDetail(isModifyDetail = true)
-                isModify = true
                 rotationY = 180f
             }
         },

--- a/app/src/main/java/com/teumteum/teumteum/util/callback/OnCurrentListChangedListener.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/callback/OnCurrentListChangedListener.kt
@@ -1,0 +1,5 @@
+package com.teumteum.teumteum.util.callback
+
+interface OnCurrentListChangedListener<T> {
+    fun onCurrentListChanged(previousList: List<T>, currentList: List<T>)
+}

--- a/app/src/main/java/com/teumteum/teumteum/util/callback/OnDeletedInterests.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/callback/OnDeletedInterests.kt
@@ -1,7 +1,0 @@
-package com.teumteum.teumteum.util.callback
-
-import com.teumteum.teumteum.util.custom.view.model.Interest
-
-interface OnDeletedInterests {
-    fun deletedInterests(deletedInterests: MutableList<Interest>)
-}

--- a/app/src/main/java/com/teumteum/teumteum/util/callback/OnDeletedInterests.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/callback/OnDeletedInterests.kt
@@ -1,0 +1,7 @@
+package com.teumteum.teumteum.util.callback
+
+import com.teumteum.teumteum.util.custom.view.model.Interest
+
+interface OnDeletedInterests {
+    fun deletedInterests(deletedInterests: MutableList<Interest>)
+}

--- a/app/src/main/java/com/teumteum/teumteum/util/callback/SampleClickListener.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/callback/SampleClickListener.kt
@@ -1,5 +1,0 @@
-package com.teumteum.teumteum.util.callback
-
-interface SampleClickListener {
-    fun selectItem(selectedItem : Any)
-}

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/itemdecoration/FlexboxItemDecoration.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/itemdecoration/FlexboxItemDecoration.kt
@@ -7,39 +7,30 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.teumteum.teumteum.util.extension.dpToPx
 
-class FlexboxItemDecoration(private val context: Context, private val horizontalSpaceDp: Int, private val verticalSpaceDp: Int) : RecyclerView.ItemDecoration() {
+class FlexboxItemDecoration(private val context: Context, private val leftSpaceDp: Int, private val topSpaceDp: Int) : RecyclerView.ItemDecoration() {
 
-    private val horizontalSpacePx = horizontalSpaceDp.dpToPx(context)
-    private val verticalSpacePx = verticalSpaceDp.dpToPx(context)
+    private val leftSpacePx = leftSpaceDp.dpToPx(context)
+    private val topSpacePx = topSpaceDp.dpToPx(context)
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         val layoutManager = parent.layoutManager as? FlexboxLayoutManager
         val position = parent.getChildAdapterPosition(view)
 
         layoutManager?.let {
-            val itemCount = parent.adapter?.itemCount ?: 0
-            val isLastRowItem = position >= itemCount - it.flexWrap
             val isFirstInRow = position % it.flexWrap == 0
 
             // 왼쪽에 아무것도 없는 첫 번째 아이템은 왼쪽 마진을 0으로 설정
             if (isFirstInRow) {
                 outRect.left = 0
             } else {
-                outRect.left = horizontalSpacePx
-            }
-
-            // 마지막 줄의 아이템은 아래 마진을 0으로 설정
-            if (isLastRowItem) {
-                outRect.bottom = 0
-            } else {
-                outRect.bottom = verticalSpacePx
+                outRect.left = leftSpacePx
             }
 
             // 상단 마진은 항상 동일하게 적용
-            outRect.top = verticalSpacePx
+            outRect.top = topSpacePx
 
             // 오른쪽 마진은 항상 동일하게 적용
-            outRect.right = horizontalSpacePx
+            outRect.right = leftSpacePx
         }
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
@@ -69,7 +69,7 @@ class BackCardView : CardView {
     fun submitInterestList(interests: List<Interest>) {
         val currentList = interestAdapter.currentList.toMutableList()
 
-        if (!currentList.any { it.interest == "추가하기" }) {
+        if (!currentList.any { it.interest == "추가하기" } && isModifyDetail) {
             currentList.add(Interest("추가하기"))
         }
 

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
@@ -12,13 +12,14 @@ import androidx.cardview.widget.CardView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import com.teumteum.teumteum.R
-import com.teumteum.teumteum.util.callback.OnDeletedInterests
+import com.teumteum.teumteum.util.callback.OnCurrentListChangedListener
 import com.teumteum.teumteum.util.custom.itemdecoration.FlexboxItemDecoration
 import com.teumteum.teumteum.util.custom.view.adapter.InterestAdapter
 import com.teumteum.teumteum.util.custom.view.model.BackCard
@@ -31,7 +32,7 @@ import timber.log.Timber
  *
  * xml, compose 모든 환경에서 뷰를 재활용 할 수 있게 커스텀뷰로 제작
  */
-class BackCardView : CardView, OnDeletedInterests {
+class BackCardView : CardView, OnCurrentListChangedListener<Interest> {
     private val layoutParent = ConstraintLayout.LayoutParams.PARENT_ID
     private var backCard = BackCard()
 
@@ -55,7 +56,7 @@ class BackCardView : CardView, OnDeletedInterests {
             ivEditGoalContent.visibility = if (value) View.VISIBLE else View.INVISIBLE
         }
 
-    var currentListAfterDelete = mutableListOf<Interest>()
+    var currentList = MutableLiveData<MutableList<Interest>>()
 
     // isModifyDetail 값을 설정하고 어댑터에 UI 갱신을 알리는 함수
     @SuppressLint("NotifyDataSetChanged")
@@ -422,8 +423,10 @@ class BackCardView : CardView, OnDeletedInterests {
         this.addView(rvInterests)
     }
 
-    override fun deletedInterests(deletedInterests: MutableList<Interest>) {
-        currentListAfterDelete = deletedInterests.filterNot { it.interest == "추가하기" }.toMutableList()
-        Timber.tag("삭제 후 관심사 리스트").d("${currentListAfterDelete}")
+    override fun onCurrentListChanged(previousList: List<Interest>, currentList: List<Interest>) {
+        Timber.tag("갱신 리스트 p").d("${previousList}")
+        Timber.tag("갱신 리스트 c").d("${currentList}")
+        this.currentList.value = currentList.filterNot { it.interest == "추가하기" }.toMutableList()
+        Timber.tag("currentList").d("${this.currentList.value}")
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
@@ -18,18 +18,20 @@ import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import com.teumteum.teumteum.R
+import com.teumteum.teumteum.util.callback.OnDeletedInterests
 import com.teumteum.teumteum.util.custom.itemdecoration.FlexboxItemDecoration
 import com.teumteum.teumteum.util.custom.view.adapter.InterestAdapter
 import com.teumteum.teumteum.util.custom.view.model.BackCard
 import com.teumteum.teumteum.util.custom.view.model.Interest
 import com.teumteum.teumteum.util.extension.dpToPx
+import timber.log.Timber
 
 /**
  * 카드 후면 뷰
  *
  * xml, compose 모든 환경에서 뷰를 재활용 할 수 있게 커스텀뷰로 제작
  */
-class BackCardView : CardView {
+class BackCardView : CardView, OnDeletedInterests {
     private val layoutParent = ConstraintLayout.LayoutParams.PARENT_ID
     private var backCard = BackCard()
 
@@ -53,6 +55,8 @@ class BackCardView : CardView {
             ivEditGoalContent.visibility = if (value) View.VISIBLE else View.INVISIBLE
         }
 
+    var currentListAfterDelete = mutableListOf<Interest>()
+
     // isModifyDetail 값을 설정하고 어댑터에 UI 갱신을 알리는 함수
     @SuppressLint("NotifyDataSetChanged")
     fun setIsModifyDetail(isModifyDetail: Boolean) {
@@ -62,7 +66,7 @@ class BackCardView : CardView {
     }
 
     // 공개 속성으로 RecyclerView와 Adapter 제공
-    val interestAdapter = InterestAdapter(context)
+    val interestAdapter = InterestAdapter(context, this)
     lateinit var rvInterests: RecyclerView
         private set
 
@@ -84,6 +88,7 @@ class BackCardView : CardView {
             interestAdapter.submitList(currentList.reversed())
         }
     }
+
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(context, attrs)
     }
@@ -415,5 +420,10 @@ class BackCardView : CardView {
         }
         rvInterests.layoutParams = layoutParams
         this.addView(rvInterests)
+    }
+
+    override fun deletedInterests(deletedInterests: MutableList<Interest>) {
+        currentListAfterDelete = deletedInterests.filterNot { it.interest == "추가하기" }.toMutableList()
+        Timber.tag("삭제 후 관심사 리스트").d("${currentListAfterDelete}")
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/BackCardView.kt
@@ -7,6 +7,7 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
+import android.widget.Toast
 import androidx.cardview.widget.CardView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -46,23 +47,43 @@ class BackCardView : CardView {
             ivFloat.visibility = if (value) View.VISIBLE else View.INVISIBLE
         }
 
+    var isModifyDetail: Boolean = false
+        set(value) {
+            field = value
+            ivEditGoalContent.visibility = if (value) View.VISIBLE else View.INVISIBLE
+        }
+
     // isModifyDetail 값을 설정하고 어댑터에 UI 갱신을 알리는 함수
     @SuppressLint("NotifyDataSetChanged")
     fun setIsModifyDetail(isModifyDetail: Boolean) {
+        this.isModifyDetail = isModifyDetail //todo - 하나의 변수를 어댑터 안팎으로 2개씩 나눠 다루고 있는데 추후 하나로 통일
         interestAdapter.isModifyDetail = isModifyDetail
-        // UI를 새로고침하도록 어댑터에 알림
         interestAdapter.notifyDataSetChanged()
     }
 
     // 공개 속성으로 RecyclerView와 Adapter 제공
-    val interestAdapter = InterestAdapter()
+    val interestAdapter = InterestAdapter(context)
     lateinit var rvInterests: RecyclerView
         private set
 
     fun submitInterestList(interests: List<Interest>) {
-        interestAdapter.submitList(interests.reversed()) //flexboxLayout에서 item 쌓이는 순서 reverse 지원을 안 해서 직접 item 순서를 뒤집어서 submitList
-    }
+        val currentList = interestAdapter.currentList.toMutableList()
 
+        if (!currentList.any { it.interest == "추가하기" }) {
+            currentList.add(Interest("추가하기"))
+        }
+
+        val availableSlots = 4 - currentList.size
+
+        if (interests.size > availableSlots) {
+            Toast.makeText(context, "최대 3개까지 선택할 수 있어요", Toast.LENGTH_SHORT).show()
+        } else {
+            val interestsToAdd = interests.take(availableSlots)
+            currentList.addAll(0, interestsToAdd)
+
+            interestAdapter.submitList(currentList.reversed())
+        }
+    }
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(context, attrs)
     }
@@ -206,8 +227,8 @@ class BackCardView : CardView {
             marginBottom = 32,
             marginStart = 32,
             marginEnd = 32,
-            itemHorizontalSpaceDp = 8,
-            itemVerticalSpaceDp = 4,
+            itemLeftSpaceDp = 8,
+            itemTopSpaceDp = 8,
         )
     }
 
@@ -344,8 +365,8 @@ class BackCardView : CardView {
         endToEndOf: Int? = null,
         endToStartOf: Int? = null,
         background: Int? = null,
-        itemHorizontalSpaceDp: Int,
-        itemVerticalSpaceDp: Int,
+        itemLeftSpaceDp: Int,
+        itemTopSpaceDp: Int,
     ) {
         rvInterests = RecyclerView(context).apply {
             this.id = id
@@ -362,8 +383,8 @@ class BackCardView : CardView {
             addItemDecoration(
                 FlexboxItemDecoration(
                     context,
-                    itemHorizontalSpaceDp,
-                    itemVerticalSpaceDp
+                    itemLeftSpaceDp,
+                    itemTopSpaceDp
                 )
             )
             background?.let { setBackgroundResource(it) }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
@@ -11,9 +11,11 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ItemInterestBinding
+import com.teumteum.teumteum.util.callback.OnDeletedInterests
 import com.teumteum.teumteum.util.custom.view.model.Interest
+import timber.log.Timber
 
-class InterestAdapter(val context: Context) : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
+class InterestAdapter(val context: Context, val onDeletedInterests: OnDeletedInterests) : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
     ItemListDiffCallback
 ) {
     var isModifyDetail: Boolean = false
@@ -39,6 +41,7 @@ class InterestAdapter(val context: Context) : ListAdapter<Interest, InterestAdap
         val newList = currentList.toMutableList().apply {
             removeAt(position)
         }
+        onDeletedInterests.deletedInterests(newList)
         submitList(newList)
     }
 

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
@@ -1,32 +1,38 @@
 package com.teumteum.teumteum.util.custom.view.adapter
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ItemInterestBinding
 import com.teumteum.teumteum.util.custom.view.model.Interest
-import timber.log.Timber
 
-class InterestAdapter() : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
+class InterestAdapter(val context: Context) : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
     ItemListDiffCallback
 ) {
-    var isModifyDetail: Boolean = false // 외부에서 접근 가능하도록 isModifyDetail 속성 추가
+    var isModifyDetail: Boolean = false
+    var onAddItemClick: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
         val binding = ItemInterestBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        // onCreateViewHolder 시점에 isModifyDetail 값을 ItemViewHolder에 전달
-        return ItemViewHolder(binding, isModifyDetail)
+        return ItemViewHolder(binding, isModifyDetail, onAddItemClick) { position ->
+            if (currentList.size > 2) {
+                removeItem(position)
+            } else {
+                Toast.makeText(context, "1개 이하는 삭제가 불가능 해요", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
-        holder.bind(getItem(position))
-        holder.binding.root.setOnClickListener {
-            removeItem(position)
-        }
+        val item = getItem(position)
+        holder.bind(item)
     }
 
     private fun removeItem(position: Int) {
@@ -36,24 +42,38 @@ class InterestAdapter() : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
         submitList(newList)
     }
 
-    class ItemViewHolder(val binding: ItemInterestBinding, private val isModifyDetail: Boolean) :
-        RecyclerView.ViewHolder(binding.root) {
+    class ItemViewHolder(
+        private val binding: ItemInterestBinding,
+        private val isModifyDetail: Boolean,
+        private val onAddItemClick: (() -> Unit)?,
+        private val onRemoveItem: (position: Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
         fun bind(item: Interest) {
-            binding.tvInterest.text = itemView.context.getString(R.string.item_interest, item.interest)
-            // 생성자를 통해 전달받은 isModifyDetail 값을 사용
-            binding.ivDelete.visibility = if (isModifyDetail) View.VISIBLE else View.GONE
+            with(binding){
+                if (item.interest == "추가하기") {
+                    tvInterest.text = item.interest
+                    tvInterest.setTextColor(ContextCompat.getColor(itemView.context, com.teumteum.base.R.color.text_button_primary_default))
+                    clInterest.setBackgroundResource(R.drawable.shape_rect4_color_outline_level01_active)
+                    ivDelete.setImageDrawable(ContextCompat.getDrawable(itemView.context,R.drawable.ic_plus_fill))
+                    root.setOnClickListener { onAddItemClick?.invoke() }
+                } else {
+                    tvInterest.text = itemView.context.getString(R.string.item_interest, item.interest)
+                    clInterest.setBackgroundResource(R.drawable.shape_rect4_background)
+                    root.setOnClickListener(null)
+                    ivDelete.setOnClickListener { onRemoveItem(absoluteAdapterPosition) }
+
+                }
+                ivDelete.visibility = if (isModifyDetail) View.VISIBLE else View.GONE
+            }
         }
     }
 
     object ItemListDiffCallback : DiffUtil.ItemCallback<Interest>() {
-        override fun areItemsTheSame(oldItem: Interest, newItem: Interest): Boolean {
-            return oldItem == newItem
-        }
+        override fun areItemsTheSame(oldItem: Interest, newItem: Interest): Boolean =
+            oldItem == newItem
 
-        override fun areContentsTheSame(
-            oldItem: Interest, newItem: Interest
-        ): Boolean {
-            return oldItem.interest == newItem.interest
-        }
+        override fun areContentsTheSame(oldItem: Interest, newItem: Interest): Boolean =
+            oldItem.interest == newItem.interest
     }
 }

--- a/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
+++ b/app/src/main/java/com/teumteum/teumteum/util/custom/view/adapter/InterestAdapter.kt
@@ -11,18 +11,21 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.teumteum.teumteum.R
 import com.teumteum.teumteum.databinding.ItemInterestBinding
-import com.teumteum.teumteum.util.callback.OnDeletedInterests
+import com.teumteum.teumteum.util.callback.OnCurrentListChangedListener
 import com.teumteum.teumteum.util.custom.view.model.Interest
-import timber.log.Timber
 
-class InterestAdapter(val context: Context, val onDeletedInterests: OnDeletedInterests) : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
+class InterestAdapter(
+    val context: Context,
+    var onCurrentListChangedListener: OnCurrentListChangedListener<Interest>,
+) : ListAdapter<Interest, InterestAdapter.ItemViewHolder>(
     ItemListDiffCallback
 ) {
     var isModifyDetail: Boolean = false
     var onAddItemClick: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
-        val binding = ItemInterestBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding =
+            ItemInterestBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ItemViewHolder(binding, isModifyDetail, onAddItemClick) { position ->
             if (currentList.size > 2) {
                 removeItem(position)
@@ -37,11 +40,18 @@ class InterestAdapter(val context: Context, val onDeletedInterests: OnDeletedInt
         holder.bind(item)
     }
 
+    override fun onCurrentListChanged(
+        previousList: MutableList<Interest>,
+        currentList: MutableList<Interest>,
+    ) {
+        super.onCurrentListChanged(previousList, currentList)
+        onCurrentListChangedListener?.onCurrentListChanged(previousList, currentList)
+    }
+
     private fun removeItem(position: Int) {
         val newList = currentList.toMutableList().apply {
             removeAt(position)
         }
-        onDeletedInterests.deletedInterests(newList)
         submitList(newList)
     }
 
@@ -49,19 +59,30 @@ class InterestAdapter(val context: Context, val onDeletedInterests: OnDeletedInt
         private val binding: ItemInterestBinding,
         private val isModifyDetail: Boolean,
         private val onAddItemClick: (() -> Unit)?,
-        private val onRemoveItem: (position: Int) -> Unit
+        private val onRemoveItem: (position: Int) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: Interest) {
-            with(binding){
+            with(binding) {
                 if (item.interest == "추가하기") {
                     tvInterest.text = item.interest
-                    tvInterest.setTextColor(ContextCompat.getColor(itemView.context, com.teumteum.base.R.color.text_button_primary_default))
+                    tvInterest.setTextColor(
+                        ContextCompat.getColor(
+                            itemView.context,
+                            com.teumteum.base.R.color.text_button_primary_default
+                        )
+                    )
                     clInterest.setBackgroundResource(R.drawable.shape_rect4_color_outline_level01_active)
-                    ivDelete.setImageDrawable(ContextCompat.getDrawable(itemView.context,R.drawable.ic_plus_fill))
+                    ivDelete.setImageDrawable(
+                        ContextCompat.getDrawable(
+                            itemView.context,
+                            R.drawable.ic_plus_fill
+                        )
+                    )
                     root.setOnClickListener { onAddItemClick?.invoke() }
                 } else {
-                    tvInterest.text = itemView.context.getString(R.string.item_interest, item.interest)
+                    tvInterest.text =
+                        itemView.context.getString(R.string.item_interest, item.interest)
                     clInterest.setBackgroundResource(R.drawable.shape_rect4_background)
                     root.setOnClickListener(null)
                     ivDelete.setOnClickListener { onRemoveItem(absoluteAdapterPosition) }

--- a/app/src/main/res/drawable-night/ic_plus_fill.xml
+++ b/app/src/main/res/drawable-night/ic_plus_fill.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="24">
     <path
         android:pathData="M5.636,18.364C9.151,21.879 14.849,21.879 18.364,18.364C21.879,14.849 21.879,9.151 18.364,5.636C14.849,2.121 9.151,2.121 5.636,5.636C2.121,9.151 2.121,14.849 5.636,18.364ZM11,16.243V13H7.757V11H11L11,7.757H13L13,11H16.243V13H13V16.243H11Z"
-        android:fillColor="#FFFFFF"
+         android:fillColor="#C9C9C9"
         android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/drawable/ic_plus_fill.xml
+++ b/app/src/main/res/drawable/ic_plus_fill.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="24">
   <path
       android:pathData="M5.636,18.364C9.151,21.879 14.849,21.879 18.364,18.364C21.879,14.849 21.879,9.151 18.364,5.636C14.849,2.121 9.151,2.121 5.636,5.636C2.121,9.151 2.121,14.849 5.636,18.364ZM11,16.243V13H7.757V11H11L11,7.757H13L13,11H16.243V13H13V16.243H11Z"
-      android:fillColor="#C9C9C9"
+      android:fillColor="#FFFFFF"
       android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/drawable/shape_rect4_color_outline_level01_active.xml
+++ b/app/src/main/res/drawable/shape_rect4_color_outline_level01_active.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/outline_level01_active" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/item_interest.xml
+++ b/app/src/main/res/layout/item_interest.xml
@@ -24,6 +24,7 @@
             app:layout_constraintEnd_toStartOf="@id/iv_delete"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_goneMarginEnd="8dp"
             tools:text="#사이드 프로젝트" />
 
         <ImageView

--- a/app/src/main/res/layout/item_interest.xml
+++ b/app/src/main/res/layout/item_interest.xml
@@ -6,10 +6,10 @@
     <data></data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_interest"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/shape_rect4_background"
-        android:padding="8dp"
         android:theme="@style/Theme.TeumTeum">
 
         <TextView
@@ -17,6 +17,8 @@
             style="@style/ta.caption.2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="8dp"
+            android:layout_marginStart="8dp"
             android:textColor="@color/text_caption_secondary_default"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/iv_delete"
@@ -26,15 +28,17 @@
 
         <ImageView
             android:id="@+id/iv_delete"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginVertical="6dp"
             android:layout_marginStart="4dp"
+            android:layout_marginEnd="8dp"
             android:src="@drawable/ic__system_fill"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/tv_interest"
-            app:layout_constraintEnd_toEndOf="@id/tv_interest"
+            app:layout_constraintBottom_toBottomOf="@id/cl_interest"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="@id/cl_interest"
             app:layout_constraintStart_toEndOf="@id/tv_interest"
-            app:layout_constraintTop_toTopOf="@id/tv_interest" />
+            app:layout_constraintTop_toTopOf="@id/cl_interest" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 📌 개요
- closed #138

## ✨ 작업 내용
- 선택 가능한 관심사 최대 3개로 제한
- 1개 이하 삭제 제한 토스트 메세지 수정
- 삭제, 추가 시 itemDecoration 충돌 나면서 간격 이상해지는 거 해결
- data 추가 시 기존 data가 안 날아가고 쌓일 수 있게 하기

## ✨ PR 포인트
- 커스텀뷰 사용법이 친절하지 못하고 깔끔하지 못한 것 같아 (ex. backCardView.interestAdapter.onAddItemClick) 추후 싹 리팩토링을 해보겠습니다.
- 관심사 추가/삭제 서버 api 연결은 직접 하셔야 됩니다.

## 📸 스크린샷/동영상

https://github.com/depromeet/TeumTeum-Android/assets/89737271/b182d7f0-dc80-48b5-b293-81ae3104ded7

| isModifyDetail 활성화 및 data 넣는 법 | 관심사 '추가' 터치 이벤트 처리 |
| :---: | :---: |
|<img width="400" src="https://github.com/depromeet/TeumTeum-Android/assets/89737271/54046d9a-17da-47de-92ec-8500be8aca6b">|<img width="400" src="https://github.com/depromeet/TeumTeum-Android/assets/89737271/016826ec-74c7-4b4b-8cd0-430e6fd9056b">|


<br>

관심사 item이 삭제되거나 추가되면 어댑터의 currentList에 변화가 생길 텐데 이를 옵저빙할 수 있는 LivaData를 만들었습니다.
ex) backCardView.currentList.observe(this){} 이런식으로 Activity나 Fragment에서 옵저빙하다가 갱신된 관심사 data list를 콜백으로 받아오면 유저 정보 갱신 api에 넣어서 서버에 반영해주면 됩니다

![스크린샷 2024-02-12 오후 10 07 57](https://github.com/depromeet/TeumTeum-Android/assets/89737271/b3516d41-369d-47ca-acba-e29ca15c026e)

![스크린샷 2024-02-12 오후 10 07 43](https://github.com/depromeet/TeumTeum-Android/assets/89737271/3cb6604c-aa8a-4b7b-99fb-f9373cbf3b5b)


