### PR TITLE
[FIX/#148] 소개서 뒤집었을 때 관심사 안 나타나고 수정 아이콘 보였던 문제 해결

### DIFF
--- a/app/src/main/java/com/teumteum/teumteum/presentation/familiar/introduce/IntroduceAdapter.kt
+++ b/app/src/main/java/com/teumteum/teumteum/presentation/familiar/introduce/IntroduceAdapter.kt
@@ -13,6 +13,7 @@ import com.bumptech.glide.request.RequestOptions
 import com.teumteum.domain.entity.Friend
 import com.teumteum.teumteum.databinding.ItemIntroduceBinding
 import com.teumteum.teumteum.util.ResMapper
+import com.teumteum.teumteum.util.custom.view.model.Interest
 
 class IntroduceAdapter() :
     ListAdapter<Friend, IntroduceAdapter.ItemViewHolder>(
@@ -104,6 +105,7 @@ class IntroduceAdapter() :
                 tvGoalTitle.text = "GOAL"
                 tvGoalTitle.setTextColor(ResMapper.getColorByCharacterId(itemView.context, item.characterId))
                 tvGoalContent.text = item.goal
+                submitInterestList(interests = item.interests.map { Interest(it) })
 
                 Glide.with(itemView.context)
                     .load(backImageRes)
@@ -111,7 +113,7 @@ class IntroduceAdapter() :
                     .into(ivCharacter)
 
                 isModify = false
-//                isModifyDetail = false
+                isModifyDetail = false
             }
         }
     }


### PR DESCRIPTION
## 📌 개요
- closed #148

## ✨ 작업 내용
 - 소개서 확인 - 뒤집었을 때 관심사 안 나타나게 하기
 - 소개서 확인 - 수정 아이콘 invisible

## ✨ PR 포인트

## 📸 스크린샷/동영상

